### PR TITLE
Rudimentary first implementation of an Info object concept

### DIFF
--- a/examples/other_features/_02_info_object.py
+++ b/examples/other_features/_02_info_object.py
@@ -1,0 +1,37 @@
+import dataclasses
+
+from typing_extensions import Self
+
+from tpcp import Pipeline, OptimizablePipeline, Dataset, Algorithm, make_action_safe, OptiPara, make_optimize_safe
+from tpcp.optimize import Optimize
+
+
+@dataclasses.dataclass
+class MyNestedAlgo(Algorithm):
+    _action_methods = ("test",)
+    para1: int
+
+    @make_action_safe
+    def test(self):
+        self.info.add("self", self.get_params())
+        self.my_result_ = 2
+        return self
+
+
+@dataclasses.dataclass
+class MyPipeline(OptimizablePipeline):
+    test_para: OptiPara[int]
+    nested: MyNestedAlgo
+
+    @make_optimize_safe
+    def self_optimize(self, dataset: Dataset, **kwargs) -> Self:
+
+        nested_clone = self.nested.clone().test()
+
+        self.info.update(params=self.get_params(), test="bla").inherit("nested", nested_clone).add(
+            "final value", "bla"
+        ).add(self.test_para, "test_para")
+        return self
+
+
+print(Optimize(MyPipeline(3, MyNestedAlgo(2))).optimize(1).optimize_info_)

--- a/tpcp/optimize/_optimize.py
+++ b/tpcp/optimize/_optimize.py
@@ -18,7 +18,7 @@ from typing_extensions import Self
 
 from tpcp import OptimizablePipeline
 from tpcp._algorithm_utils import OPTIMIZE_METHOD_INDICATOR, _check_safe_optimize
-from tpcp._base import _get_annotated_fields_of_type
+from tpcp._base import _get_annotated_fields_of_type, Info, clone
 from tpcp._dataset import DatasetT
 from tpcp._optimize import BaseOptimize
 from tpcp._parameters import Parameter, _ParaTypes
@@ -140,6 +140,7 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
     safe_optimize: bool
 
     optimized_pipeline_: OptimizablePipelineT
+    optimize_info_: Info
 
     def __init__(  # noqa: super-init-not-called
         self, pipeline: OptimizablePipelineT, *, safe_optimize: bool = True
@@ -184,6 +185,7 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
         else:
             optimized_pipeline = pipeline.self_optimize(dataset, **optimize_params)
         # We clone again, just to be sure
+        self.optimize_info_ = clone(optimized_pipeline.info.to_dict())
         self.optimized_pipeline_ = optimized_pipeline.clone()
         return self
 


### PR DESCRIPTION
One remaining issue in the fundamental design of tpcp is that it was basically impossible to extract informations from the trainings process. This PR tests an approach, where it is possible to fill an "info" dictionary during a `self_optimize` (or `run` call). The `Optimize` method has been made aware of this object and stores it as a result. This way it can be accessed when running GridSearchCV or other methods.