### PR TITLE
Set datetime precision when saving the snapshot as json to the highes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Scorer class now has the ability to score datapoints in parallel.
   This can be enabled by setting the `n_jobs` parameter of the `Scorer` class to something larger than 1.
   (https://github.com/mad-lab-fau/tpcp/pull/95)
+- The `PyTestSnapshotTest` class does now support comparing dataframes with datetime columns.
+  (https://github.com/mad-lab-fau/tpcp/pull/97)
 
 ## [0.24.0] - 2023-09-08
 

--- a/tpcp/testing/_regression_utils.py
+++ b/tpcp/testing/_regression_utils.py
@@ -107,7 +107,7 @@ class PyTestSnapshotTest:
     def _store(self, value):
         self._snapshot_folder.mkdir(parents=True, exist_ok=True)
         if isinstance(value, pd.DataFrame):
-            value.to_json(self._file_name_json, indent=4, orient="table")
+            value.to_json(self._file_name_json, indent=4, orient="table", date_unit="ns")
         elif isinstance(value, np.ndarray):
             np.savetxt(self._file_name_csv, value, delimiter=",")
         elif isinstance(value, str):


### PR DESCRIPTION
…t possible value. This prevents datetimes in mikro/nanoseconds from being rounded.