### PR TITLE
[codex] Preserve explicit scorer multiprocessing settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `validate` overwriting multiprocessing parameters configured on explicit `Scorer` instances.
+  (https://github.com/mad-lab-fau/tpcp/pull/129)
 - Improved snapshot test mismatch reporting to include the snapshot file path and detailed comparator output for
   DataFrame, NumPy array, and string snapshot failures.
 

--- a/src/tpcp/validate/_validate.py
+++ b/src/tpcp/validate/_validate.py
@@ -195,25 +195,23 @@ def validate(
         True/False to enable/disable a `tqdm` progress bar.
     """
     scoring_args = {"n_jobs": n_jobs, "verbose": verbose, "pre_dispatch": pre_dispatch, "progress_bar": progress_bar}
-    # iterate over args that will be passed to Scorer
-    for arg, value in scoring_args.items():
-        # when a Scorer instance is provided, the respective arguments were already set
-        if isinstance(scoring, Scorer) and not isinstance(value, _Default):
-            raise ValueError(  # noqa: TRY004
+    if isinstance(scoring, Scorer):
+        for arg, value in scoring_args.items():
+            if isinstance(value, _Default):
+                continue
+            raise ValueError(
                 "You passed a explicit Scorer object for the scoring parameter. In this case, we expect "
                 f"multiprocessing parameters ({list(scoring_args.keys())}) to be configured directly on the "
                 f"Scorer instance. However, you specified {arg}={value} by passing it directly "
                 "to the validate function. Instead, pass multiprocessing parameters to your Scorer during "
                 "initialization or by using `set_params`."
             )
-
-        # extract the value from _Default instances
-        if isinstance(value, _Default):
-            scoring_args[arg] = value.get_value()
-
-    scoring = _validate_scorer(scoring)
-
-    scoring.set_params(**scoring_args)
+        scoring = _validate_scorer(scoring)
+    else:
+        scoring = _validate_scorer(scoring)
+        scoring.set_params(
+            **{arg: value.get_value() if isinstance(value, _Default) else value for arg, value in scoring_args.items()}
+        )
 
     results = _score(
         pipeline.clone(),

--- a/tests/test_pipelines/test_validate.py
+++ b/tests/test_pipelines/test_validate.py
@@ -112,6 +112,18 @@ class TestValidate:
         assert isinstance(scorer, Scorer)
         assert all(scorer.get_params()[arg] == val for arg, val in multiprocess_args.items())
 
+    @patch("tpcp.validate._validate._score", autospec=True)
+    def test_explicit_scorer_keeps_configured_multiprocessing_parameters(self, mock_score):
+        """Check if validate preserves multiprocessing arguments configured on an explicit scorer."""
+        multiprocess_args = {"n_jobs": 6, "verbose": 10, "pre_dispatch": 3, "progress_bar": False}
+        scorer = Scorer(dummy_single_score_func, **multiprocess_args)
+
+        validate(DummyPipeline(), DummyDataset(), scoring=scorer)
+
+        assert mock_score.call_args is not None  # _score function was called
+        used_scorer = mock_score.call_args.args[2]
+        assert {arg: used_scorer.get_params()[arg] for arg in multiprocess_args} == multiprocess_args
+
 
 class TestCrossValidate:
     @pytest.mark.filterwarnings("ignore::tpcp.exceptions.PotentialUserErrorWarning")


### PR DESCRIPTION
## Summary

Fixes `validate()` so an explicit `Scorer` keeps its configured multiprocessing parameters when the corresponding `validate()` arguments are omitted.

## Root Cause

`validate()` converted omitted `_Default(...)` multiprocessing arguments into concrete default values and then always called `scoring.set_params(**scoring_args)`. For explicit `Scorer` instances, that reset values such as `n_jobs`, `verbose`, `pre_dispatch`, and `progress_bar` even though the API tells callers to configure those values on the scorer itself.

## Changes

- Preserve existing `Scorer` multiprocessing parameters when `validate()` receives an explicit scorer and no direct multiprocessing kwargs.
- Keep the existing `ValueError` when callers pass multiprocessing kwargs both through an explicit `Scorer` and directly to `validate()`.
- Add a regression test covering explicit scorer preservation.

Closes #128.

## Validation

- `uv run pytest tests/test_pipelines/test_validate.py -q`
- `uv run poe ci_check`
- `uv sync --locked --all-extras --group dev`
- `uv run poe test` (`554 passed, 11 skipped`)

## Review

- roborev job `2738`: no issues found, commented, and closed.