### PR TITLE
Add warning and error context metadata

### DIFF
--- a/.agents/refactor-policy.md
+++ b/.agents/refactor-policy.md
@@ -1,0 +1,5 @@
+# Backwards-compatibility policy
+
+- **Backwards compatibility is mandatory** for all public interfaces and supported behavior; changes must be additive and non-breaking by default.
+- Internal interfaces may be refactored freely when all in-repository consumers are updated in the same change, provided no public behavior or interface is broken.
+- Public breaking changes require explicit user approval as a scoped exception, a clear migration path, and prominent flags in code review, changelogs, and delivery reports; reviewers must reject unapproved breaks.

--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,5 @@ _debug_test
 # joss paper compile output
 paper/paper.pdf
 paper/paper.jats
+# roborev snapshots
+/.roborev/

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,4 @@
+# Project-specific review guidelines
+review_guidelines = """
+Backwards compatibility is mandatory for all public interfaces and supported behavior; flag and reject unapproved breaking changes. Internal refactors may proceed when every in-repository consumer is updated and public behavior remains stable. A public breaking change is permitted only as an explicitly approved, scoped exception with a migration path and prominent communication in code review, changelogs, and delivery reports.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent guidance
+
+## Repository-local skills and refactoring
+
+- When the same skill name is available from multiple locations, always use the repository-local skill under `$REPO_ROOT/.agents/skills/`. Repository-local skills take precedence over user-global skills. Do not load or apply the corresponding skill from `$HOME/.agents/skills/` when a repository-local version exists.
+- Consider the repository's current publication state and backwards-compatibility requirements recorded in `.agents/refactor-policy.md` in all interactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (https://github.com/mad-lab-fau/tpcp/pull/133)
 - Added `tpcp.misc.warning_error_context`, a stackable context manager for enriching warnings and exceptions with
   structured context metadata.
+  Contexts retain warning, error, and `print_with_context` records for later inspection, and an outer record-only mode
+  can collect contextual diagnostics without emitting warning or progress output.
   This is now used by validation, cross-validation, grid search, scorer datapoint loops, typed iterator warning
   contexts, and Optuna trial evaluation to make failures and warnings identify the active fold, parameter candidate,
   datapoint, trial, or iterator item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `tpcp.misc.warning_error_context`, a stackable context manager for enriching warnings and exceptions with
   structured context metadata.
   Contexts retain warning, error, and `print_with_context` records for later inspection, and an outer record-only mode
-  can collect contextual diagnostics without emitting warning or progress output.
+  can collect contextual diagnostics without emitting warning or progress output. Contexts can also be started and
+  stopped explicitly when a long script should not be indented under a `with` statement.
   This is now used by validation, cross-validation, grid search, scorer datapoint loops, typed iterator warning
   contexts, and Optuna trial evaluation to make failures and warnings identify the active fold, parameter candidate,
   datapoint, trial, or iterator item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an advanced recipe showing how to expose predefined parameters and pretrained models for algorithms.
   (https://github.com/mad-lab-fau/tpcp/pull/133)
+- Added `tpcp.misc.warning_error_context`, a stackable context manager for enriching warnings and exceptions with
+  structured context metadata.
+  This is now used by validation, cross-validation, grid search, scorer datapoint loops, typed iterator warning
+  contexts, and Optuna trial evaluation to make failures and warnings identify the active fold, parameter candidate,
+  datapoint, trial, or iterator item.
+  (https://github.com/mad-lab-fau/tpcp/pull/131)
+
+### Changed
+
+- **Breaking:** Error and warning text from `validate`, `cross_validate`, `GridSearch`, `GridSearchCV`, `Scorer`,
+  `TypedIterator`, and Optuna optimization now includes structured context metadata instead of the previous ad-hoc
+  error strings.
+  Code or tests that match exact warning or exception messages need to be updated.
+  (https://github.com/mad-lab-fau/tpcp/pull/131)
+- **Breaking:** The private `_score` and `_optimize_and_score` helpers no longer accept `error_info`; callers must pass
+  structured context entries instead.
+  (https://github.com/mad-lab-fau/tpcp/pull/131)
 
 ## [2.2.1] - 2026-06-15
 

--- a/docs/modules/misc.rst
+++ b/docs/modules/misc.rst
@@ -27,4 +27,4 @@ Functions
     custom_hash
     classproperty
     set_defaults
-
+    warning_error_context

--- a/docs/modules/misc.rst
+++ b/docs/modules/misc.rst
@@ -29,5 +29,6 @@ Functions
     custom_hash
     classproperty
     iter_with_warning_error_context
+    print_with_context
     set_defaults
     warning_error_context

--- a/docs/modules/misc.rst
+++ b/docs/modules/misc.rst
@@ -16,6 +16,8 @@ Classes
 
     BaseTypedIterator
     TypedIterator
+    WarningErrorContext
+    WarningErrorContextRecord
 
 
 Functions

--- a/docs/modules/misc.rst
+++ b/docs/modules/misc.rst
@@ -26,5 +26,6 @@ Functions
 
     custom_hash
     classproperty
+    iter_with_warning_error_context
     set_defaults
     warning_error_context

--- a/examples/recipies/_07_warning_error_context.py
+++ b/examples/recipies/_07_warning_error_context.py
@@ -14,8 +14,8 @@ iterators, :class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
 Simple and dynamic context
 --------------------------
 Pass fixed values as a dictionary. Warning messages retain their original
-warning type and source location, with the active context prepended to the
-message.
+warning type and source location. The original message is followed by a
+contextual copy on a separate line.
 """
 
 import warnings
@@ -86,10 +86,34 @@ except ValueError as error:
 # context creator. Enter the returned context explicitly inside the loop body.
 # The creator automatically adds the zero-based iteration index as ``i``; all
 # other values remain explicit.
+#
+# Python normally suppresses repeated warnings from the same source line. This
+# filtering happens before context is attached, so different context values do
+# not make the warnings distinct. Applications that need every contextual
+# occurrence can enable an appropriate warning filter. Here, ``catch_warnings``
+# only scopes that filter; warnings still emit normally for Sphinx-Gallery.
+with warnings.catch_warnings():
+    warnings.simplefilter("always")
+    for make_context, item in iter_with_warning_error_context(
+        ["left", "right"]
+    ):
+        with make_context("item", {"value": item}):
+            warnings.warn("iterator warning", UserWarning, stacklevel=1)
 
-for make_context, item in iter_with_warning_error_context(["left", "right"]):
-    with make_context("item", {"value": item}):
-        warnings.warn("iterator warning", UserWarning, stacklevel=1)
+# %%
+# Combining regular and iterator contexts
+# ---------------------------------------
+# An iterator context composes with any regular context that is already active.
+# The regular context is rendered first, followed by the per-iteration context
+# and its automatically injected ``i``.
+with warnings.catch_warnings():
+    warnings.simplefilter("always")
+    with warning_error_context("dataset", {"name": "validation"}):
+        for make_context, item in iter_with_warning_error_context(
+            ["left", "right"]
+        ):
+            with make_context("item", {"value": item}):
+                warnings.warn("stacked warning", UserWarning, stacklevel=1)
 
 # %%
 # TypedIterator
@@ -109,10 +133,12 @@ class Result:
 
 typed_iterator = TypedIterator[int, Result](Result)
 
-for item, result in typed_iterator.iterate([2, 4]):
-    with typed_iterator.warning_error_context("item", {"value": item}):
-        warnings.warn("typed warning", UserWarning, stacklevel=1)
-        result.doubled = item * 2
+with warnings.catch_warnings():
+    warnings.simplefilter("always")
+    for item, result in typed_iterator.iterate([2, 4]):
+        with typed_iterator.warning_error_context("item", {"value": item}):
+            warnings.warn("typed warning", UserWarning, stacklevel=1)
+            result.doubled = item * 2
 
 print(typed_iterator.results_.doubled)
 
@@ -141,23 +167,25 @@ class NestedIterator(BaseTypedIterator[int, Result]):
 
 nested_iterator = NestedIterator(Result)
 
-for outer, outer_result in nested_iterator.iterate([10]):
-    with nested_iterator.warning_error_context("outer", {"value": outer}):
-        warnings.warn("outer before", UserWarning, stacklevel=1)
+with warnings.catch_warnings():
+    warnings.simplefilter("always")
+    for outer, outer_result in nested_iterator.iterate([10]):
+        with nested_iterator.warning_error_context("outer", {"value": outer}):
+            warnings.warn("outer before", UserWarning, stacklevel=1)
 
-    for inner, inner_result in nested_iterator.iterate_subitems([20, 21]):
-        with nested_iterator.warning_error_context(
-            "inner",
-            context_provider=lambda inner=inner: {"value": inner},
-        ):
-            warnings.warn("inner", UserWarning, stacklevel=1)
-            inner_result.doubled = inner * 2
+        for inner, inner_result in nested_iterator.iterate_subitems([20, 21]):
+            with nested_iterator.warning_error_context(
+                "inner",
+                context_provider=lambda inner=inner: {"value": inner},
+            ):
+                warnings.warn("inner", UserWarning, stacklevel=1)
+                inner_result.doubled = inner * 2
 
-    # No fixed dictionary is required. This context contains only the restored
-    # outer ``i``.
-    with nested_iterator.warning_error_context("outer_after"):
-        warnings.warn("outer after", UserWarning, stacklevel=1)
-        outer_result.doubled = outer * 2
+        # No fixed dictionary is required. This context contains only the
+        # restored outer ``i``.
+        with nested_iterator.warning_error_context("outer_after"):
+            warnings.warn("outer after", UserWarning, stacklevel=1)
+            outer_result.doubled = outer * 2
 
 # %%
 # In all iterator variants, the context manager is created and entered inside

--- a/examples/recipies/_07_warning_error_context.py
+++ b/examples/recipies/_07_warning_error_context.py
@@ -1,0 +1,165 @@
+# ruff: noqa: D205, D400
+"""
+Warning and Error Context
+=========================
+
+The :func:`~tpcp.misc.warning_error_context` helper adds structured context to
+warnings and exceptions without changing the code that emits them. This is
+useful when a low-level warning or error does not know which dataset item,
+optimization trial, or iteration triggered it.
+
+This example covers fixed and dynamic context, nested contexts, arbitrary
+iterators, :class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
+
+Simple and dynamic context
+--------------------------
+Pass fixed values as a dictionary. Warning messages retain their original
+warning type and source location, with the active context prepended to the
+message.
+"""
+
+import warnings
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+from tpcp.misc import (
+    BaseTypedIterator,
+    TypedIterator,
+    iter_with_warning_error_context,
+    warning_error_context,
+)
+
+with warning_error_context("record", {"participant": "p1"}):
+    warnings.warn("signal is short", UserWarning, stacklevel=1)
+
+# %%
+# A ``context_provider`` is evaluated only when a warning or exception is
+# rendered. It can be used without passing an empty context dictionary. This is
+# useful for state that changes while the context is active.
+state = {"step": 0}
+
+with warning_error_context(
+    "processing",
+    context_provider=lambda: {"step": state["step"]},
+):
+    state["step"] = 2
+    warnings.warn("processing warning", UserWarning, stacklevel=1)
+
+# %%
+# Fixed context and a provider can also be combined. Provider keys must not
+# duplicate keys from the fixed dictionary.
+with warning_error_context(
+    "processing",
+    {"participant": "p1"},
+    context_provider=lambda: {"step": state["step"]},
+):
+    warnings.warn("combined warning", UserWarning, stacklevel=1)
+
+# %%
+# Nested contexts
+# ---------------
+# Contexts compose from outermost to innermost. Each context is removed when its
+# ``with`` block ends.
+with warning_error_context("participant", {"id": "p1"}):  # noqa: SIM117 - Python 3.9 compatibility
+    with warning_error_context("recording", {"id": 3}):
+        warnings.warn("nested warning", UserWarning, stacklevel=1)
+
+# %%
+# Errors
+# ------
+# The context manager re-raises the original error, so it can be caught and
+# handled normally. The active context is attached to the caught exception
+# through exception notes. On Python 3.11 and newer, the standard traceback
+# renderer displays these notes. On Python 3.9 and 3.10, renderers with
+# exception-note support, such as Rich, can display them.
+try:
+    with warning_error_context("recording", {"id": 3}):
+        raise ValueError("invalid signal")
+except ValueError as error:
+    print(f"Caught error: {error}")
+    print(f"Context: {getattr(error, '__notes__', [])}")
+
+# %%
+# Arbitrary iterators
+# -------------------
+# :func:`~tpcp.misc.iter_with_warning_error_context` pairs each item with a
+# context creator. Enter the returned context explicitly inside the loop body.
+# The creator automatically adds the zero-based iteration index as ``i``; all
+# other values remain explicit.
+
+for make_context, item in iter_with_warning_error_context(["left", "right"]):
+    with make_context("item", {"value": item}):
+        warnings.warn("iterator warning", UserWarning, stacklevel=1)
+
+# %%
+# TypedIterator
+# -------------
+# :class:`~tpcp.misc.TypedIterator` exposes the same context-creation interface.
+# While an item is yielded, ``warning_error_context`` reads the current
+# zero-based index from the iterator and injects it as ``i``. No other item
+# metadata is inferred.
+
+
+@dataclass
+class Result:
+    """Result created for one iteration."""
+
+    doubled: int
+
+
+typed_iterator = TypedIterator[int, Result](Result)
+
+for item, result in typed_iterator.iterate([2, 4]):
+    with typed_iterator.warning_error_context("item", {"value": item}):
+        warnings.warn("typed warning", UserWarning, stacklevel=1)
+        result.doubled = item * 2
+
+print(typed_iterator.results_.doubled)
+
+# %%
+# TypedIterator sub-iterations
+# ----------------------------
+# Custom typed iterators can expose sub-iterations by wrapping the protected
+# ``_iterate`` helper. The same ``warning_error_context`` method then binds to
+# whichever iteration is currently yielding. Every sub-iteration starts its own
+# ``i`` at zero, and completing it restores the outer iteration's ``i``.
+
+
+class NestedIterator(BaseTypedIterator[int, Result]):
+    """Typed iterator with an outer iteration and an explicit sub-iteration."""
+
+    def iterate(self, values: Iterable[int]) -> Iterator[tuple[int, Result]]:
+        """Iterate over outer values."""
+        yield from self._iterate(values)
+
+    def iterate_subitems(
+        self, values: Iterable[int]
+    ) -> Iterator[tuple[int, Result]]:
+        """Iterate over values belonging to the current outer item."""
+        yield from self._iterate(values, iteration_name="subitems")
+
+
+nested_iterator = NestedIterator(Result)
+
+for outer, outer_result in nested_iterator.iterate([10]):
+    with nested_iterator.warning_error_context("outer", {"value": outer}):
+        warnings.warn("outer before", UserWarning, stacklevel=1)
+
+    for inner, inner_result in nested_iterator.iterate_subitems([20, 21]):
+        with nested_iterator.warning_error_context(
+            "inner",
+            context_provider=lambda inner=inner: {"value": inner},
+        ):
+            warnings.warn("inner", UserWarning, stacklevel=1)
+            inner_result.doubled = inner * 2
+
+    # No fixed dictionary is required. This context contains only the restored
+    # outer ``i``.
+    with nested_iterator.warning_error_context("outer_after"):
+        warnings.warn("outer after", UserWarning, stacklevel=1)
+        outer_result.doubled = outer * 2
+
+# %%
+# In all iterator variants, the context manager is created and entered inside
+# the loop body. This keeps its lifetime explicit and prevents context from
+# leaking across a generator's ``yield`` boundary.

--- a/examples/recipies/_07_warning_error_context.py
+++ b/examples/recipies/_07_warning_error_context.py
@@ -8,8 +8,9 @@ warnings and exceptions without changing the code that emits them. This is
 useful when a low-level warning or error does not know which dataset item,
 optimization trial, or iteration triggered it.
 
-This example covers fixed and dynamic context, nested contexts, arbitrary
-iterators, :class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
+This example covers fixed and dynamic context, nested contexts, retained event
+records, contextual prints, quiet record-only execution, arbitrary iterators,
+:class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
 
 Simple and dynamic context
 --------------------------
@@ -26,6 +27,7 @@ from tpcp.misc import (
     BaseTypedIterator,
     TypedIterator,
     iter_with_warning_error_context,
+    print_with_context,
     warning_error_context,
 )
 
@@ -78,6 +80,72 @@ try:
 except ValueError as error:
     print(f"Caught error: {error}")
     print(f"Context: {getattr(error, '__notes__', [])}")
+
+# %%
+# Recording events and contextual prints
+# ---------------------------------------
+# Every context manager yields a persistent result whose ``records`` list can
+# be inspected after the context exits. Each named-tuple record contains the
+# event type (``"warning"``, ``"error"``, or ``"print"``), the fully resolved
+# context stack, and the original warning/exception object or print message.
+# Nested events are included in every active context result.
+#
+# :func:`~tpcp.misc.print_with_context` accepts the normal ``print`` arguments.
+# With an active context, it prepends the rendered context and adds a record.
+# Without an active context, it behaves like a normal ``print``.
+items = ["ok", "short", "invalid"]
+
+with warnings.catch_warnings():
+    # Warning filters run before tpcp can record a warning. Use ``always`` when
+    # every repeated occurrence is relevant to the later analysis.
+    warnings.simplefilter("always")
+    with warning_error_context(
+        "dataset", {"name": "validation"}
+    ) as dataset_context:
+        for make_context, item in iter_with_warning_error_context(items):
+            try:
+                with make_context("datapoint", {"value": item}):
+                    print_with_context("Processing", item)
+                    if item != "ok":
+                        warnings.warn(
+                            "signal quality issue", UserWarning, stacklevel=1
+                        )
+                    if item == "invalid":
+                        raise ValueError("invalid signal")
+            except ValueError:
+                # Errors are recorded when they leave a context. They still
+                # propagate normally and can be handled by the application.
+                pass
+
+print([record.type for record in dataset_context.records])
+
+warning_contexts = [
+    record.context
+    for record in dataset_context.records
+    if record.type == "warning" and isinstance(record.message, UserWarning)
+]
+print(warning_contexts)
+
+# %%
+# Quiet record-only mode
+# ----------------------
+# A high-level ``record_only=True`` context suppresses contextual warning and
+# ``print_with_context`` output from all nested contexts while retaining the
+# same records. It does not suppress errors or ordinary ``print`` calls. This is
+# useful for wrapping a long-running program and printing only a final summary.
+with warnings.catch_warnings():
+    warnings.simplefilter("always")
+    with warning_error_context(
+        "program", {"mode": "batch"}, record_only=True
+    ) as program_context:
+        for make_context, item in iter_with_warning_error_context(
+            ["left", "right"]
+        ):
+            with make_context("datapoint", {"value": item}):
+                warnings.warn("quiet warning", UserWarning, stacklevel=1)
+                print_with_context("Processed", item)
+
+print([record.type for record in program_context.records])
 
 # %%
 # Arbitrary iterators

--- a/examples/recipies/_07_warning_error_context.py
+++ b/examples/recipies/_07_warning_error_context.py
@@ -9,8 +9,9 @@ useful when a low-level warning or error does not know which dataset item,
 optimization trial, or iteration triggered it.
 
 This example covers fixed and dynamic context, nested contexts, retained event
-records, contextual prints, quiet record-only execution, arbitrary iterators,
-:class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
+records, contextual prints, manual lifecycle control, quiet record-only
+execution, arbitrary iterators, :class:`~tpcp.misc.TypedIterator`, and typed
+sub-iterations.
 
 Simple and dynamic context
 --------------------------
@@ -80,6 +81,28 @@ try:
 except ValueError as error:
     print(f"Caught error: {error}")
     print(f"Context: {getattr(error, '__notes__', [])}")
+
+# %%
+# Manual lifecycle
+# ----------------
+# For a long top-level script, the object returned by
+# :func:`~tpcp.misc.warning_error_context` can be started and stopped explicitly
+# to avoid indenting the entire guarded section.
+manual_context = warning_error_context("script", {"phase": "processing"})
+manual_context.start()
+warnings.warn("manual warning", UserWarning, stacklevel=1)
+print_with_context("Manual context is active")
+manual_context.stop()
+
+print([record.type for record in manual_context.records])
+
+# %%
+# Manual lifecycle control has an important exception caveat. ``stop()`` does
+# not receive an active exception, so it cannot record or annotate one. If an
+# exception prevents ``stop()`` from running, the context also remains active.
+# A ``try``/``finally`` can guarantee cleanup, but the bare ``stop()`` call
+# still cannot add exception context. Use the ``with`` form whenever exceptions
+# must be recorded, annotated, or cleanly unwind the context.
 
 # %%
 # Recording events and contextual prints

--- a/src/tpcp/_utils/_score.py
+++ b/src/tpcp/_utils/_score.py
@@ -18,7 +18,7 @@ from tpcp._base import clone
 from tpcp._hash import custom_hash
 from tpcp._utils._general import _get_nested_paras
 from tpcp.exceptions import OptimizationError, TestError
-from tpcp.misc import warning_error_context
+from tpcp.misc._warning_error_context import _render_contexts, warning_error_context
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -63,6 +63,15 @@ def _contextualize(context: Optional[Sequence[tuple[str, dict[str, Any]]]]) -> E
     for name, metadata in context or ():
         stack.enter_context(warning_error_context(name, **metadata))
     return stack
+
+
+def _contextualized_error_message(
+    message: str,
+    context: Optional[Sequence[tuple[str, dict[str, Any]]]],
+    phase: str,
+    **phase_metadata: Any,
+) -> str:
+    return f"{message}\nContext: {_render_contexts([*(context or ()), (phase, phase_metadata)])}"
 
 
 def _score(
@@ -122,7 +131,9 @@ def _score(
                 agg_scores, single_scores = scorer(pipeline, dataset)
             score_time = time.time() - start_time
         except Exception as e:
-            raise TestError("Testing failed.") from e
+            raise TestError(
+                _contextualized_error_message("Testing failed.", context, "score", data_labels=dataset.group_labels)
+            ) from e
 
     result: _ScoreResults = {
         "scores": agg_scores,
@@ -196,7 +207,11 @@ def _optimize_and_score(
                 )
             optimize_time = time.time() - start_time
         except Exception as e:
-            raise OptimizationError("Optimization failed.") from e
+            raise OptimizationError(
+                _contextualized_error_message(
+                    "Optimization failed.", context, "optimize", data_labels=train_set.group_labels
+                )
+            ) from e
 
         # Now we set the remaining paras.
         # Because, we need to set the parameters on the optimized pipeline and not the input pipeline we strip the
@@ -212,7 +227,11 @@ def _optimize_and_score(
                 agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
             score_time = time.time() - optimize_time - start_time
         except Exception as e:
-            raise TestError("Testing failed.") from e
+            raise TestError(
+                _contextualized_error_message(
+                    "Testing failed.", context, "test_score", data_labels=test_set.group_labels
+                )
+            ) from e
 
         result: _OptimizeScoreResults = {
             "test__scores": agg_scores,
@@ -223,7 +242,11 @@ def _optimize_and_score(
                 with warning_error_context("train_score", data_labels=train_set.group_labels):
                     train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
             except Exception as e:
-                raise TestError("Testing failed.") from e
+                raise TestError(
+                    _contextualized_error_message(
+                        "Testing failed.", context, "train_score", data_labels=train_set.group_labels
+                    )
+                ) from e
             result["train__scores"] = train_agg_scores
             result["train__single__scores"] = train_single_scores
         if return_times:

--- a/src/tpcp/_utils/_score.py
+++ b/src/tpcp/_utils/_score.py
@@ -125,15 +125,15 @@ def _score(
 
             pipeline = pipeline.set_params(**parameters)
 
+        score_context: dict[str, Any] = {}
         try:
             start_time = time.time()
-            with warning_error_context("score", data_labels=dataset.group_labels):
+            score_context = {"data_labels": dataset.group_labels}
+            with warning_error_context("score", **score_context):
                 agg_scores, single_scores = scorer(pipeline, dataset)
             score_time = time.time() - start_time
         except Exception as e:
-            raise TestError(
-                _contextualized_error_message("Testing failed.", context, "score", data_labels=dataset.group_labels)
-            ) from e
+            raise TestError(_contextualized_error_message("Testing failed.", context, "score", **score_context)) from e
 
     result: _ScoreResults = {
         "scores": agg_scores,
@@ -199,18 +199,18 @@ def _optimize_and_score(
 
         optimize_params_clean: dict = optimize_params or {}
 
+        optimize_context: dict[str, Any] = {}
         try:
             start_time = time.time()
-            with warning_error_context("optimize", data_labels=train_set.group_labels):
+            optimize_context = {"data_labels": train_set.group_labels}
+            with warning_error_context("optimize", **optimize_context):
                 optimizer = _cached_optimize(
                     optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
                 )
             optimize_time = time.time() - start_time
         except Exception as e:
             raise OptimizationError(
-                _contextualized_error_message(
-                    "Optimization failed.", context, "optimize", data_labels=train_set.group_labels
-                )
+                _contextualized_error_message("Optimization failed.", context, "optimize", **optimize_context)
             ) from e
 
         # Now we set the remaining paras.
@@ -222,15 +222,15 @@ def _optimize_and_score(
         # beginning.
         optimizer = optimizer.set_params(**pure_parameters)
 
+        test_score_context: dict[str, Any] = {}
         try:
-            with warning_error_context("test_score", data_labels=test_set.group_labels):
+            test_score_context = {"data_labels": test_set.group_labels}
+            with warning_error_context("test_score", **test_score_context):
                 agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
             score_time = time.time() - optimize_time - start_time
         except Exception as e:
             raise TestError(
-                _contextualized_error_message(
-                    "Testing failed.", context, "test_score", data_labels=test_set.group_labels
-                )
+                _contextualized_error_message("Testing failed.", context, "test_score", **test_score_context)
             ) from e
 
         result: _OptimizeScoreResults = {
@@ -238,14 +238,14 @@ def _optimize_and_score(
             "test__single__scores": single_scores,
         }
         if return_train_score:
+            train_score_context: dict[str, Any] = {}
             try:
-                with warning_error_context("train_score", data_labels=train_set.group_labels):
+                train_score_context = {"data_labels": train_set.group_labels}
+                with warning_error_context("train_score", **train_score_context):
                     train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
             except Exception as e:
                 raise TestError(
-                    _contextualized_error_message(
-                        "Testing failed.", context, "train_score", data_labels=train_set.group_labels
-                    )
+                    _contextualized_error_message("Testing failed.", context, "train_score", **train_score_context)
                 ) from e
             result["train__scores"] = train_agg_scores
             result["train__single__scores"] = train_single_scores

--- a/src/tpcp/_utils/_score.py
+++ b/src/tpcp/_utils/_score.py
@@ -61,7 +61,7 @@ class _OptimizeScoreResults(TypedDict, total=False):
 def _contextualize(context: Optional[Sequence[tuple[str, dict[str, Any]]]]) -> ExitStack:
     stack = ExitStack()
     for name, metadata in context or ():
-        stack.enter_context(warning_error_context(name, **metadata))
+        stack.enter_context(warning_error_context(name, metadata))
     return stack
 
 
@@ -129,7 +129,7 @@ def _score(
         try:
             start_time = time.time()
             score_context = {"data_labels": dataset.group_labels}
-            with warning_error_context("score", **score_context):
+            with warning_error_context("score", score_context):
                 agg_scores, single_scores = scorer(pipeline, dataset)
             score_time = time.time() - start_time
         except Exception as e:
@@ -203,7 +203,7 @@ def _optimize_and_score(
         try:
             start_time = time.time()
             optimize_context = {"data_labels": train_set.group_labels}
-            with warning_error_context("optimize", **optimize_context):
+            with warning_error_context("optimize", optimize_context):
                 optimizer = _cached_optimize(
                     optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
                 )
@@ -225,7 +225,7 @@ def _optimize_and_score(
         test_score_context: dict[str, Any] = {}
         try:
             test_score_context = {"data_labels": test_set.group_labels}
-            with warning_error_context("test_score", **test_score_context):
+            with warning_error_context("test_score", test_score_context):
                 agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
             score_time = time.time() - optimize_time - start_time
         except Exception as e:
@@ -241,7 +241,7 @@ def _optimize_and_score(
             train_score_context: dict[str, Any] = {}
             try:
                 train_score_context = {"data_labels": train_set.group_labels}
-                with warning_error_context("train_score", **train_score_context):
+                with warning_error_context("train_score", train_score_context):
                     train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
             except Exception as e:
                 raise TestError(

--- a/src/tpcp/_utils/_score.py
+++ b/src/tpcp/_utils/_score.py
@@ -8,6 +8,7 @@ The original code is licenced under BSD-3: https://github.com/scikit-learn/sciki
 from __future__ import annotations
 
 import time
+from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from joblib import Memory
@@ -17,8 +18,11 @@ from tpcp._base import clone
 from tpcp._hash import custom_hash
 from tpcp._utils._general import _get_nested_paras
 from tpcp.exceptions import OptimizationError, TestError
+from tpcp.misc import warning_error_context
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from tpcp._dataset import Dataset
     from tpcp._optimize import BaseOptimize
     from tpcp._pipeline import Pipeline
@@ -54,6 +58,13 @@ class _OptimizeScoreResults(TypedDict, total=False):
     optimizer: BaseOptimize
 
 
+def _contextualize(context: Optional[Sequence[tuple[str, dict[str, Any]]]]) -> ExitStack:
+    stack = ExitStack()
+    for name, metadata in context or ():
+        stack.enter_context(warning_error_context(name, **metadata))
+    return stack
+
+
 def _score(
     pipeline: Pipeline,
     dataset: Dataset,
@@ -62,7 +73,7 @@ def _score(
     return_parameters=False,
     return_data_labels=False,
     return_times=False,
-    error_info: Optional[str] = None,
+    context: Optional[Sequence[tuple[str, dict[str, Any]]]] = None,
 ) -> _ScoreResults:
     """Set parameters and return score.
 
@@ -98,21 +109,20 @@ def _score(
             The parameters that have been evaluated.
 
     """
-    if parameters is not None:
-        # clone after setting parameters in case any parameters are estimators (like pipeline steps).
-        parameters = _clone_parameter_dict(parameters)
+    with _contextualize(context):
+        if parameters is not None:
+            # clone after setting parameters in case any parameters are estimators (like pipeline steps).
+            parameters = _clone_parameter_dict(parameters)
 
-        pipeline = pipeline.set_params(**parameters)
+            pipeline = pipeline.set_params(**parameters)
 
-    try:
-        start_time = time.time()
-        agg_scores, single_scores = scorer(pipeline, dataset)
-        score_time = time.time() - start_time
-    except Exception as e:
-        raise TestError(
-            f"Testing the algorithm on the dataset failed with the error above.\n{error_info or ''}\n\n"
-            f"The test-set is:\n{[d.group_labels for d in dataset]}"
-        ) from e
+        try:
+            start_time = time.time()
+            with warning_error_context("score", data_labels=dataset.group_labels):
+                agg_scores, single_scores = scorer(pipeline, dataset)
+            score_time = time.time() - start_time
+        except Exception as e:
+            raise TestError("Testing failed.") from e
 
     result: _ScoreResults = {
         "scores": agg_scores,
@@ -142,7 +152,7 @@ def _optimize_and_score(
     return_data_labels=False,
     return_times=False,
     memory: Optional[Memory] = None,
-    error_info: Optional[str] = None,
+    context: Optional[Sequence[tuple[str, dict[str, Any]]]] = None,
 ) -> _OptimizeScoreResults:
     """Optimize and score the optimized pipeline on the train and test data, respectively.
 
@@ -169,74 +179,68 @@ def _optimize_and_score(
     Let's better be safe and reduce the surface for bugs even further here.
 
     """
-    if memory is None:
-        memory = Memory(None)
-    # clone after setting parameters in case any parameters are estimators (like pipeline steps).
-    hyperparameters = _clone_parameter_dict(hyperparameters)
-    pure_parameters = _clone_parameter_dict(pure_parameters)
+    with _contextualize(context):
+        if memory is None:
+            memory = Memory(None)
+        # clone after setting parameters in case any parameters are estimators (like pipeline steps).
+        hyperparameters = _clone_parameter_dict(hyperparameters)
+        pure_parameters = _clone_parameter_dict(pure_parameters)
 
-    optimize_params_clean: dict = optimize_params or {}
+        optimize_params_clean: dict = optimize_params or {}
 
-    try:
-        start_time = time.time()
-        optimizer = _cached_optimize(
-            optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
-        )
-        optimize_time = time.time() - start_time
-    except Exception as e:
-        raise OptimizationError(
-            f"The optimization on the trainset failed with the error above.\n{error_info or ''}\n\n"
-            f"This optimization used the following trainset:\n{train_set}"
-        ) from e
-
-    # Now we set the remaining paras.
-    # Because, we need to set the parameters on the optimized pipeline and not the input pipeline we strip the
-    # naming prefix.
-    striped_paras = _get_nested_paras(pure_parameters, "pipeline")
-    optimizer.optimized_pipeline_.set_params(**striped_paras)
-    # We also set the parameters of the input pipeline to make it seem that all parameters were set from the
-    # beginning.
-    optimizer = optimizer.set_params(**pure_parameters)
-
-    try:
-        agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
-        score_time = time.time() - optimize_time - start_time
-    except Exception as e:
-        raise TestError(
-            f"Testing the optimized algorithm on the test-set failed with the error above.\n{error_info or ''}\n\n"
-            f"The test-set is:\n{test_set}"
-        ) from e
-
-    result: _OptimizeScoreResults = {
-        "test__scores": agg_scores,
-        "test__single__scores": single_scores,
-    }
-    if return_train_score:
         try:
-            train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
+            start_time = time.time()
+            with warning_error_context("optimize", data_labels=train_set.group_labels):
+                optimizer = _cached_optimize(
+                    optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
+                )
+            optimize_time = time.time() - start_time
         except Exception as e:
-            raise TestError(
-                "Running the optimized algorithm on the train-set to calculate the train error failed with the error "
-                f"above.\n{error_info or ''}\n\n"
-                f"The train-set is:\n{[d.group_labels for d in test_set]}"
-            ) from e
-        result["train__scores"] = train_agg_scores
-        result["train__single__scores"] = train_single_scores
-    if return_times:
-        result["debug__score_time"] = score_time
-        result["debug__optimize_time"] = optimize_time
-    if return_data_labels:
-        # Note we always return the train data attribute as it is interesting information independent of the train
-        # score and has 0 runtime impact.
-        result["train__data_labels"] = train_set.group_labels
-        result["test__data_labels"] = test_set.group_labels
-    if return_optimizer:
-        # This is the actual trained optimizer. This means that `optimizer.optimized_pipeline_` contains the actual
-        # instance of the trained pipeline.
-        result["optimizer"] = optimizer
-    if return_parameters:
-        result["parameters"] = {**hyperparameters, **pure_parameters}
-    return result
+            raise OptimizationError("Optimization failed.") from e
+
+        # Now we set the remaining paras.
+        # Because, we need to set the parameters on the optimized pipeline and not the input pipeline we strip the
+        # naming prefix.
+        striped_paras = _get_nested_paras(pure_parameters, "pipeline")
+        optimizer.optimized_pipeline_.set_params(**striped_paras)
+        # We also set the parameters of the input pipeline to make it seem that all parameters were set from the
+        # beginning.
+        optimizer = optimizer.set_params(**pure_parameters)
+
+        try:
+            with warning_error_context("test_score", data_labels=test_set.group_labels):
+                agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
+            score_time = time.time() - optimize_time - start_time
+        except Exception as e:
+            raise TestError("Testing failed.") from e
+
+        result: _OptimizeScoreResults = {
+            "test__scores": agg_scores,
+            "test__single__scores": single_scores,
+        }
+        if return_train_score:
+            try:
+                with warning_error_context("train_score", data_labels=train_set.group_labels):
+                    train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
+            except Exception as e:
+                raise TestError("Testing failed.") from e
+            result["train__scores"] = train_agg_scores
+            result["train__single__scores"] = train_single_scores
+        if return_times:
+            result["debug__score_time"] = score_time
+            result["debug__optimize_time"] = optimize_time
+        if return_data_labels:
+            # Note we always return the train data attribute as it is interesting information independent of the train
+            # score and has 0 runtime impact.
+            result["train__data_labels"] = train_set.group_labels
+            result["test__data_labels"] = test_set.group_labels
+        if return_optimizer:
+            # This is the actual trained optimizer. This means that `optimizer.optimized_pipeline_` contains the actual
+            # instance of the trained pipeline.
+            result["optimizer"] = optimizer
+        if return_parameters:
+            result["parameters"] = {**hyperparameters, **pure_parameters}
+        return result
 
 
 def _cached_optimize(

--- a/src/tpcp/misc/__init__.py
+++ b/src/tpcp/misc/__init__.py
@@ -3,12 +3,19 @@
 from tpcp._hash import custom_hash
 from tpcp.misc._class_utils import classproperty, set_defaults
 from tpcp.misc._typed_iterator import BaseTypedIterator, TypedIterator, TypedIteratorResultTuple
-from tpcp.misc._warning_error_context import iter_with_warning_error_context, warning_error_context
+from tpcp.misc._warning_error_context import (
+    WarningErrorContext,
+    WarningErrorContextRecord,
+    iter_with_warning_error_context,
+    warning_error_context,
+)
 
 __all__ = [
     "BaseTypedIterator",
     "TypedIterator",
     "TypedIteratorResultTuple",
+    "WarningErrorContext",
+    "WarningErrorContextRecord",
     "classproperty",
     "custom_hash",
     "iter_with_warning_error_context",

--- a/src/tpcp/misc/__init__.py
+++ b/src/tpcp/misc/__init__.py
@@ -3,7 +3,7 @@
 from tpcp._hash import custom_hash
 from tpcp.misc._class_utils import classproperty, set_defaults
 from tpcp.misc._typed_iterator import BaseTypedIterator, TypedIterator, TypedIteratorResultTuple
-from tpcp.misc._warning_error_context import warning_error_context
+from tpcp.misc._warning_error_context import iter_with_warning_error_context, warning_error_context
 
 __all__ = [
     "BaseTypedIterator",
@@ -11,6 +11,7 @@ __all__ = [
     "TypedIteratorResultTuple",
     "classproperty",
     "custom_hash",
+    "iter_with_warning_error_context",
     "set_defaults",
     "warning_error_context",
 ]

--- a/src/tpcp/misc/__init__.py
+++ b/src/tpcp/misc/__init__.py
@@ -3,6 +3,7 @@
 from tpcp._hash import custom_hash
 from tpcp.misc._class_utils import classproperty, set_defaults
 from tpcp.misc._typed_iterator import BaseTypedIterator, TypedIterator, TypedIteratorResultTuple
+from tpcp.misc._warning_error_context import warning_error_context
 
 __all__ = [
     "BaseTypedIterator",
@@ -11,4 +12,5 @@ __all__ = [
     "classproperty",
     "custom_hash",
     "set_defaults",
+    "warning_error_context",
 ]

--- a/src/tpcp/misc/__init__.py
+++ b/src/tpcp/misc/__init__.py
@@ -7,6 +7,7 @@ from tpcp.misc._warning_error_context import (
     WarningErrorContext,
     WarningErrorContextRecord,
     iter_with_warning_error_context,
+    print_with_context,
     warning_error_context,
 )
 
@@ -19,6 +20,7 @@ __all__ = [
     "classproperty",
     "custom_hash",
     "iter_with_warning_error_context",
+    "print_with_context",
     "set_defaults",
     "warning_error_context",
 ]

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -28,6 +28,7 @@ class _NotSet:
 
 
 _NULL_VALUE = _NotSet()
+_NO_PREVIOUS_ITERATION_INDEX = object()
 
 
 class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
@@ -179,30 +180,47 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
             self._raw_results = []
 
         self.done_[iteration_name] = False
-        for d in iterable:
+        for i, d in enumerate(iterable):
             result_object = self._get_new_empty_object()
             iteration_context = iteration_context or {}
             result_tuple = TypedIteratorResultTuple(iteration_name, d, result_object, iteration_context)
             self._report_new_result(result_tuple)
-            yield d, result_object
+            previous_i = getattr(self, "_warning_error_context_i", _NO_PREVIOUS_ITERATION_INDEX)
+            self._warning_error_context_i = i
+            try:
+                yield d, result_object
+            finally:
+                if previous_i is _NO_PREVIOUS_ITERATION_INDEX:
+                    del self._warning_error_context_i
+                else:
+                    self._warning_error_context_i = previous_i
         self.done_[iteration_name] = True
 
     def warning_error_context(
         self,
         name: str,
+        context: dict[str, Any],
         /,
         *,
-        metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
-        **metadata: Any,
+        context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
     ) -> AbstractContextManager[None]:
         """Create explicit warning/error context for an iteration body.
 
         This convenience method has the same interface as
-        :func:`~tpcp.misc.warning_error_context`. It deliberately does not infer
-        metadata from the iterator or its current item. Enter the returned context
-        manager inside the iteration body and pass all relevant metadata explicitly.
+        :func:`~tpcp.misc.warning_error_context` and adds the current zero-based
+        iteration index as ``i``. It deliberately does not infer any other context
+        from the iterator or its current item. Enter the returned context manager
+        inside the iteration body and pass all other relevant context explicitly.
         """
-        return _warning_error_context(name, metadata_provider=metadata_provider, **metadata)
+        if "i" in context:
+            raise ValueError("The context key 'i' is reserved by TypedIterator.")
+        try:
+            i = self._warning_error_context_i
+        except AttributeError as exc:
+            raise RuntimeError(
+                "warning_error_context must be called inside an active TypedIterator loop body."
+            ) from exc
+        return _warning_error_context(name, {"i": i, **context}, context_provider=context_provider)
 
     def _get_new_empty_object(self) -> DataclassT:
         init_dict = {k.name: self.NULL_VALUE for k in fields(self.data_type)}

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -160,6 +160,9 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
             The result object is a dataclass instance of the type defined in ``self.data_type``.
             All values of the result object are set to ``TypedIterator.NULL_VALUE`` by default.
 
+            Warnings emitted by the loop body include the active iteration context. Exceptions raised by the loop body
+            happen outside the generator boundary and can not be annotated here.
+
         """
         if not is_dataclass(self.data_type):
             raise TypeError(f"Expected a dataclass as data_type, got {self.data_type}")

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Generic, Optional, TypeVar
 from typing_extensions import NamedTuple, TypeAlias
 
 from tpcp import Algorithm, cf
+from tpcp.misc._warning_error_context import warning_error_context
 
 DataclassT = TypeVar("DataclassT")
 InputTypeT = TypeVar("InputTypeT")
@@ -175,9 +176,16 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
         self.done_[iteration_name] = False
         for d in iterable:
             result_object = self._get_new_empty_object()
-            result_tuple = TypedIteratorResultTuple(iteration_name, d, result_object, iteration_context or {})
+            iteration_context = iteration_context or {}
+            result_tuple = TypedIteratorResultTuple(iteration_name, d, result_object, iteration_context)
             self._report_new_result(result_tuple)
-            yield d, result_object
+            with warning_error_context(
+                "typed_iterator_iteration",
+                iteration_name=iteration_name,
+                input=d,
+                iteration_context=iteration_context,
+            ):
+                yield d, result_object
         self.done_[iteration_name] = True
 
     def _get_new_empty_object(self) -> DataclassT:

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -1,6 +1,5 @@
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from contextlib import AbstractContextManager
 from dataclasses import fields, is_dataclass
 from typing import Any, Generic, Optional, TypeVar
 
@@ -205,7 +204,7 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
         record_only: bool = False,
-    ) -> AbstractContextManager[WarningErrorContext]:
+    ) -> WarningErrorContext:
         """Create explicit warning/error context for an iteration body.
 
         This convenience method has the same interface as

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -199,7 +199,7 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
     def warning_error_context(
         self,
         name: str,
-        context: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
@@ -212,6 +212,7 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
         from the iterator or its current item. Enter the returned context manager
         inside the iteration body and pass all other relevant context explicitly.
         """
+        context = {} if context is None else context
         if "i" in context:
             raise ValueError("The context key 'i' is reserved by TypedIterator.")
         try:

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -204,6 +204,7 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+        record_only: bool = False,
     ) -> AbstractContextManager[WarningErrorContext]:
         """Create explicit warning/error context for an iteration body.
 
@@ -222,7 +223,12 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
             raise RuntimeError(
                 "warning_error_context must be called inside an active TypedIterator loop body."
             ) from exc
-        return _warning_error_context(name, {"i": i, **context}, context_provider=context_provider)
+        return _warning_error_context(
+            name,
+            {"i": i, **context},
+            context_provider=context_provider,
+            record_only=record_only,
+        )
 
     def _get_new_empty_object(self) -> DataclassT:
         init_dict = {k.name: self.NULL_VALUE for k in fields(self.data_type)}

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -1,12 +1,13 @@
 import warnings
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from contextlib import AbstractContextManager
 from dataclasses import fields, is_dataclass
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from typing_extensions import NamedTuple, TypeAlias
 
 from tpcp import Algorithm, cf
-from tpcp.misc._warning_error_context import warning_error_context
+from tpcp.misc._warning_error_context import warning_error_context as _warning_error_context
 
 DataclassT = TypeVar("DataclassT")
 InputTypeT = TypeVar("InputTypeT")
@@ -160,8 +161,9 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
             The result object is a dataclass instance of the type defined in ``self.data_type``.
             All values of the result object are set to ``TypedIterator.NULL_VALUE`` by default.
 
-            Warnings emitted by the loop body include the active iteration context. Exceptions raised by the loop body
-            happen outside the generator boundary and can not be annotated here.
+            To add context to warnings and exceptions from the loop body, explicitly enter
+            :meth:`warning_error_context` inside the loop. Context must not remain active across this generator's
+            ``yield`` boundary.
 
         """
         if not is_dataclass(self.data_type):
@@ -182,14 +184,25 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
             iteration_context = iteration_context or {}
             result_tuple = TypedIteratorResultTuple(iteration_name, d, result_object, iteration_context)
             self._report_new_result(result_tuple)
-            with warning_error_context(
-                "typed_iterator_iteration",
-                iteration_name=iteration_name,
-                input=d,
-                iteration_context=iteration_context,
-            ):
-                yield d, result_object
+            yield d, result_object
         self.done_[iteration_name] = True
+
+    def warning_error_context(
+        self,
+        name: str,
+        /,
+        *,
+        metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+        **metadata: Any,
+    ) -> AbstractContextManager[None]:
+        """Create explicit warning/error context for an iteration body.
+
+        This convenience method has the same interface as
+        :func:`~tpcp.misc.warning_error_context`. It deliberately does not infer
+        metadata from the iterator or its current item. Enter the returned context
+        manager inside the iteration body and pass all relevant metadata explicitly.
+        """
+        return _warning_error_context(name, metadata_provider=metadata_provider, **metadata)
 
     def _get_new_empty_object(self) -> DataclassT:
         init_dict = {k.name: self.NULL_VALUE for k in fields(self.data_type)}

--- a/src/tpcp/misc/_typed_iterator.py
+++ b/src/tpcp/misc/_typed_iterator.py
@@ -7,6 +7,7 @@ from typing import Any, Generic, Optional, TypeVar
 from typing_extensions import NamedTuple, TypeAlias
 
 from tpcp import Algorithm, cf
+from tpcp.misc._warning_error_context import WarningErrorContext
 from tpcp.misc._warning_error_context import warning_error_context as _warning_error_context
 
 DataclassT = TypeVar("DataclassT")
@@ -203,7 +204,7 @@ class BaseTypedIterator(Algorithm, Generic[InputTypeT, DataclassT]):
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
-    ) -> AbstractContextManager[None]:
+    ) -> AbstractContextManager[WarningErrorContext]:
         """Create explicit warning/error context for an iteration body.
 
         This convenience method has the same interface as

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
 
 
 @dataclass(frozen=True)
@@ -28,6 +28,10 @@ _warn = warnings.warn
 
 def _render_context_stack() -> str:
     return " > ".join(frame.render() for frame in _context_stack.get())
+
+
+def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
+    return " > ".join(_ContextFrame(name=name, metadata=metadata).render() for name, metadata in contexts)
 
 
 def _warning_with_context(message: Warning, context: str) -> Warning:

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -6,6 +6,7 @@ from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from copy import copy
 from dataclasses import dataclass, field
+from io import StringIO
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -80,6 +81,7 @@ class _ContextFrame:
     context: dict[str, Any]
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None
     result: WarningErrorContext = field(default_factory=WarningErrorContext)
+    record_only: bool = False
 
     def _render_context(self) -> str:
         context = self.context
@@ -124,6 +126,10 @@ def _record_event(
     record = WarningErrorContextRecord(event_type, context, message)
     for frame in _context_stack.get():
         frame.result.records.append(record)
+
+
+def _is_record_only() -> bool:
+    return any(frame.record_only for frame in _context_stack.get())
 
 
 def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
@@ -187,6 +193,8 @@ def _showwarnmsg_with_context(message: warnings.WarningMessage) -> None:
     if _context_stack.get():
         context = _render_context_stack()
         _record_event("warning", context, message.message)
+        if _is_record_only():
+            return
         message = copy(message)
         message.message = _contextualize_warning(message.message, context)
 
@@ -216,6 +224,8 @@ else:
         context = _render_context_stack()
         if context:
             _record_event("warning", context, message)
+            if _is_record_only():
+                return
         _original_showwarning(_contextualize_warning(message, context), category, filename, lineno, file, line)
 
     warnings.showwarning = _showwarning_with_context
@@ -246,6 +256,7 @@ def warning_error_context(
     /,
     *,
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+    record_only: bool = False,
 ) -> Generator[WarningErrorContext, None, None]:
     """Add structured context information to warnings and exceptions raised in the context.
 
@@ -260,14 +271,21 @@ def warning_error_context(
 
     Python applies warning filters before this context manager attaches its metadata.
     Consequently, different context values do not make otherwise identical warnings
-    count as distinct occurrences. If every contextual occurrence must be shown, use
-    an appropriate warning filter such as ``warnings.simplefilter("always")``.
+    count as distinct occurrences. If every contextual occurrence must be shown or
+    recorded, use an appropriate warning filter such as
+    ``warnings.simplefilter("always")``.
 
     The context manager yields a :class:`WarningErrorContext` whose ``records`` list
     remains available after the context exits. It contains warnings that reached
     Python's warning dispatcher and exceptions that escaped the context. Original
     warning and exception objects are retained so callers can inspect their concrete
     types and custom attributes.
+
+    Setting ``record_only=True`` on an outer context suppresses warning forwarding
+    and :func:`print_with_context` output throughout its nested contexts while still
+    recording those events. It does not suppress exceptions or ordinary
+    :func:`print` calls. Warning filters still run before recording, including in
+    record-only mode.
 
     On Python 3.9 and 3.10, exception context is stored in ``__notes__`` but is not
     displayed by Python's standard traceback renderer. Traceback renderers that
@@ -279,6 +297,7 @@ def warning_error_context(
         context=dict({} if context is None else context),
         context_provider=context_provider,
         result=result,
+        record_only=record_only,
     )
     token = _context_stack.set((*_context_stack.get(), frame))
     try:
@@ -296,6 +315,39 @@ def warning_error_context(
             _recorded_error.set(None)
 
 
+def print_with_context(
+    *values: Any,
+    sep: Optional[str] = " ",
+    end: Optional[str] = "\n",
+    file: Any = None,
+    flush: bool = False,
+) -> None:
+    """Print values with the active context and retain the original message.
+
+    Without an active :func:`warning_error_context`, this behaves exactly like
+    :func:`print`. With an active context, the rendered context stack is prepended
+    to the output and a ``"print"`` record is added to every active context result.
+    Output is suppressed when any active context uses ``record_only=True``.
+    """
+    if not _context_stack.get():
+        print(*values, sep=sep, end=end, file=file, flush=flush)
+        return
+
+    if sep is not None and not isinstance(sep, str):
+        raise TypeError(f"sep must be None or a string, not {type(sep).__name__}")
+    if end is not None and not isinstance(end, str):
+        raise TypeError(f"end must be None or a string, not {type(end).__name__}")
+
+    message_buffer = StringIO()
+    print(*values, sep=sep, end="", file=message_buffer)
+    message = message_buffer.getvalue()
+    context = _render_context_stack()
+    _record_event("print", context, message)
+    if _is_record_only():
+        return
+    print(f"[{context}] {message}", end=end, file=file, flush=flush)
+
+
 def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
     def make_context(
         name: str,
@@ -303,11 +355,17 @@ def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+        record_only: bool = False,
     ) -> AbstractContextManager[WarningErrorContext]:
         context = {} if context is None else context
         if "i" in context:
             raise ValueError("The context key 'i' is reserved by iter_with_warning_error_context.")
-        return warning_error_context(name, {"i": i, **context}, context_provider=context_provider)
+        return warning_error_context(
+            name,
+            {"i": i, **context},
+            context_provider=context_provider,
+            record_only=record_only,
+        )
 
     return make_context
 

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@dataclass(frozen=True)
+class _ContextFrame:
+    name: str
+    metadata: dict[str, Any]
+
+    def render(self) -> str:
+        if not self.metadata:
+            return self.name
+        metadata = ", ".join(f"{key}={value!r}" for key, value in self.metadata.items())
+        return f"{self.name}: {metadata}"
+
+
+_context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
+_warn = warnings.warn
+
+
+def _render_context_stack() -> str:
+    return " > ".join(frame.render() for frame in _context_stack.get())
+
+
+def _warn_with_context(
+    message: Union[Warning, str],
+    category: Optional[type[Warning]] = None,
+    stacklevel: int = 1,
+    source: Any = None,
+) -> None:
+    context = _render_context_stack()
+    if not context:
+        _warn(message, category=category, stacklevel=stacklevel, source=source)
+        return
+
+    if isinstance(message, Warning):
+        category = category or type(message)
+        message = str(message)
+
+    _warn(f"[{context}] {message}", category=category, stacklevel=stacklevel + 1, source=source)
+
+
+warnings.warn = _warn_with_context
+
+
+def _add_note(exc: BaseException, note: str) -> None:
+    add_note = getattr(exc, "add_note", None)
+    if add_note is not None:
+        add_note(note)
+        return
+
+    notes = getattr(exc, "__notes__", [])
+    notes.append(note)
+    exc.__notes__ = notes
+
+
+@contextmanager
+def warning_error_context(name: str, /, **metadata: Any) -> Generator[None, None, None]:
+    """Add structured context information to warnings and exceptions raised in the context."""
+    frame = _ContextFrame(name=name, metadata=metadata)
+    token = _context_stack.set((*_context_stack.get(), frame))
+    try:
+        yield
+    except BaseException as exc:
+        _add_note(exc, f"Context: {frame.render()}")
+        raise
+    finally:
+        _context_stack.reset(token)

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -354,6 +354,13 @@ def warning_error_context(
     warning and exception objects are retained so callers can inspect their concrete
     types and custom attributes.
 
+    The returned object can also be activated with :meth:`WarningErrorContext.start`
+    and deactivated with :meth:`WarningErrorContext.stop`, which avoids indenting a
+    long script. Manual use cannot automatically record or annotate an exception:
+    ``stop()`` does not receive exception information, and an exception that skips
+    the call leaves the context active. Use the ``with`` form whenever exception-safe
+    cleanup or contextualized exceptions are required.
+
     Setting ``record_only=True`` on an outer context suppresses warning forwarding
     and :func:`print_with_context` output throughout its nested contexts while still
     recording those events. It does not suppress exceptions or ordinary

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -165,14 +165,21 @@ else:
 
 
 def _add_note(exc: BaseException, note: str) -> None:
-    add_note = getattr(exc, "add_note", None)
-    if add_note is not None:
-        add_note(note)
-        return
+    try:
+        add_note = getattr(exc, "add_note", None)
+        if callable(add_note):
+            add_note(note)
+            return
+    except BaseException:  # noqa: BLE001 - diagnostic context must never replace the original exception
+        pass
 
-    notes = getattr(exc, "__notes__", [])
-    notes.append(note)
-    setattr(exc, "__notes__", notes)
+    try:
+        notes = list(getattr(exc, "__notes__", []))
+        if not notes or notes[-1] != note:
+            notes.append(note)
+        setattr(exc, "__notes__", notes)
+    except BaseException:  # noqa: BLE001 - re-raising the original exception is more important than its note
+        pass
 
 
 @contextmanager

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -46,7 +46,7 @@ def _warn_with_context(
 ) -> None:
     context = _render_context_stack()
     if not context:
-        _warn(message, category=category, stacklevel=stacklevel, source=source, **kwargs)
+        _warn(message, category=category, stacklevel=stacklevel + 1, source=source, **kwargs)
         return
 
     if isinstance(message, Warning):

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -174,16 +174,17 @@ def _add_note(exc: BaseException, note: str) -> None:
 @contextmanager
 def warning_error_context(
     name: str,
-    context: dict[str, Any],
+    context: Optional[dict[str, Any]] = None,
     /,
     *,
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
 ) -> Generator[None, None, None]:
     """Add structured context information to warnings and exceptions raised in the context.
 
-    ``context`` is copied when the context is entered. ``context_provider`` is
-    evaluated whenever context is rendered, allowing diagnostics to include state
-    that changes while the context is active. The provider must return a mapping and
+    If provided, ``context`` is copied when the context is entered.
+    ``context_provider`` is evaluated whenever context is rendered, allowing
+    diagnostics to include state that changes while the context is active. It can be
+    used without a fixed context dictionary. The provider must return a mapping and
     must not repeat fixed context keys.
 
     A failing provider is represented in the rendered context instead of masking the
@@ -193,7 +194,9 @@ def warning_error_context(
     displayed by Python's standard traceback renderer. Traceback renderers that
     support exception notes, such as Rich, display this context on those versions.
     """
-    frame = _ContextFrame(name=name, context=dict(context), context_provider=context_provider)
+    frame = _ContextFrame(
+        name=name, context=dict({} if context is None else context), context_provider=context_provider
+    )
     token = _context_stack.set((*_context_stack.get(), frame))
     try:
         yield
@@ -207,11 +210,12 @@ def warning_error_context(
 def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
     def make_context(
         name: str,
-        context: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
     ) -> AbstractContextManager[None]:
+        context = {} if context is None else context
         if "i" in context:
             raise ValueError("The context key 'i' is reserved by iter_with_warning_error_context.")
         return warning_error_context(name, {"i": i, **context}, context_provider=context_provider)

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -78,6 +78,10 @@ def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
     return " > ".join(_ContextFrame(name=name, context=context).render() for name, context in contexts)
 
 
+def _warning_message_with_context(message: str, context: str) -> str:
+    return f"{message}\n[{context}] {message}"
+
+
 def _warning_with_context(message: Warning, context: str) -> Warning:
     # Calling the concrete type's constructor is not safe: warning subclasses can
     # require extra arguments in __new__. BaseException can allocate every Warning
@@ -100,7 +104,7 @@ def _warning_with_context(message: Warning, context: str) -> Warning:
             except AttributeError:
                 continue
             slot_descriptor.__set__(contextualized_warning, slot_value)
-    contextualized_warning.args = (f"[{context}] {message}", *message.args[1:])
+    contextualized_warning.args = (_warning_message_with_context(str(message), context), *message.args[1:])
     return contextualized_warning
 
 
@@ -109,7 +113,7 @@ def _contextualize_warning(message: Union[Warning, str]) -> Union[Warning, str]:
     if not context:
         return message
     if isinstance(message, str):
-        return f"[{context}] {message}"
+        return _warning_message_with_context(message, context)
     return _warning_with_context(message, context)
 
 
@@ -189,6 +193,11 @@ def warning_error_context(
 
     A failing provider is represented in the rendered context instead of masking the
     warning or exception that caused context rendering.
+
+    Python applies warning filters before this context manager attaches its metadata.
+    Consequently, different context values do not make otherwise identical warnings
+    count as distinct occurrences. If every contextual occurrence must be shown, use
+    an appropriate warning filter such as ``warnings.simplefilter("always")``.
 
     On Python 3.9 and 3.10, exception context is stored in ``__notes__`` but is not
     displayed by Python's standard traceback renderer. Traceback renderers that

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -15,37 +15,56 @@ T = TypeVar("T")
 _WarningErrorContextFactory = Callable[..., AbstractContextManager[None]]
 
 
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except BaseException as exc:  # noqa: BLE001 - diagnostic rendering must never replace the original event
+        return f"<repr failed: {type(exc).__name__}>"
+
+
+def _render_context_values(context: Mapping[str, Any]) -> str:
+    return ", ".join(f"{key}={_safe_repr(value)}" for key, value in context.items())
+
+
+def _safe_exception_description(exc: BaseException) -> str:
+    try:
+        message = str(exc)
+    except BaseException as render_exc:  # noqa: BLE001 - diagnostic rendering must never replace the original event
+        message = f"<str failed: {type(render_exc).__name__}>"
+    return f"{type(exc).__name__}: {message}"
+
+
 @dataclass(frozen=True)
 class _ContextFrame:
     name: str
-    metadata: dict[str, Any]
-    metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None
+    context: dict[str, Any]
+    context_provider: Optional[Callable[[], Mapping[str, Any]]] = None
 
-    def _render_metadata(self) -> str:
-        metadata = self.metadata
-        if self.metadata_provider is not None:
+    def _render_context(self) -> str:
+        context = self.context
+        if self.context_provider is not None:
             try:
-                provided_metadata = self.metadata_provider()
-                if not isinstance(provided_metadata, Mapping):
-                    raise TypeError("metadata_provider must return a mapping")
-                duplicate_keys = metadata.keys() & provided_metadata.keys()
+                provided_context = self.context_provider()
+                if not isinstance(provided_context, Mapping):
+                    raise TypeError("context_provider must return a mapping")
+                duplicate_keys = context.keys() & provided_context.keys()
                 if duplicate_keys:
                     duplicates = ", ".join(sorted(duplicate_keys))
-                    raise ValueError(f"metadata_provider returned duplicate keys: {duplicates}")
-                metadata = {**metadata, **provided_metadata}
+                    raise ValueError(f"context_provider returned duplicate keys: {duplicates}")
+                context = {**context, **provided_context}
             except BaseException as exc:  # noqa: BLE001 - context rendering must not mask the original event
-                provider_error = f"{type(exc).__name__}: {exc}"
-                rendered_metadata = ", ".join(f"{key}={value!r}" for key, value in metadata.items())
-                rendered_error = f"metadata_provider_error={provider_error!r}"
-                return ", ".join(filter(None, (rendered_metadata, rendered_error)))
+                provider_error = _safe_exception_description(exc)
+                rendered_context = _render_context_values(context)
+                rendered_error = f"context_provider_error={provider_error!r}"
+                return ", ".join(filter(None, (rendered_context, rendered_error)))
 
-        return ", ".join(f"{key}={value!r}" for key, value in metadata.items())
+        return _render_context_values(context)
 
     def render(self) -> str:
-        rendered_metadata = self._render_metadata()
-        if not rendered_metadata:
+        rendered_context = self._render_context()
+        if not rendered_context:
             return self.name
-        return f"{self.name}: {rendered_metadata}"
+        return f"{self.name}: {rendered_context}"
 
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
@@ -56,7 +75,7 @@ def _render_context_stack() -> str:
 
 
 def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
-    return " > ".join(_ContextFrame(name=name, metadata=metadata).render() for name, metadata in contexts)
+    return " > ".join(_ContextFrame(name=name, context=context).render() for name, context in contexts)
 
 
 def _warning_with_context(message: Warning, context: str) -> Warning:
@@ -155,17 +174,17 @@ def _add_note(exc: BaseException, note: str) -> None:
 @contextmanager
 def warning_error_context(
     name: str,
+    context: dict[str, Any],
     /,
     *,
-    metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
-    **metadata: Any,
+    context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
 ) -> Generator[None, None, None]:
     """Add structured context information to warnings and exceptions raised in the context.
 
-    ``metadata`` values are fixed when the context is entered. ``metadata_provider``
-    is evaluated whenever context is rendered, allowing diagnostics to include state
+    ``context`` is copied when the context is entered. ``context_provider`` is
+    evaluated whenever context is rendered, allowing diagnostics to include state
     that changes while the context is active. The provider must return a mapping and
-    must not repeat fixed metadata keys.
+    must not repeat fixed context keys.
 
     A failing provider is represented in the rendered context instead of masking the
     warning or exception that caused context rendering.
@@ -174,7 +193,7 @@ def warning_error_context(
     displayed by Python's standard traceback renderer. Traceback renderers that
     support exception notes, such as Rich, display this context on those versions.
     """
-    frame = _ContextFrame(name=name, metadata=metadata, metadata_provider=metadata_provider)
+    frame = _ContextFrame(name=name, context=dict(context), context_provider=context_provider)
     token = _context_stack.set((*_context_stack.get(), frame))
     try:
         yield
@@ -185,14 +204,30 @@ def warning_error_context(
         _context_stack.reset(token)
 
 
+def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
+    def make_context(
+        name: str,
+        context: dict[str, Any],
+        /,
+        *,
+        context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+    ) -> AbstractContextManager[None]:
+        if "i" in context:
+            raise ValueError("The context key 'i' is reserved by iter_with_warning_error_context.")
+        return warning_error_context(name, {"i": i, **context}, context_provider=context_provider)
+
+    return make_context
+
+
 def iter_with_warning_error_context(
     iterable: Iterable[T],
 ) -> Iterator[tuple[_WarningErrorContextFactory, T]]:
     """Pair every item with a warning/error context creator.
 
-    The creator has the same interface as :func:`warning_error_context` and does
-    not infer metadata from the item. Enter it explicitly in the loop body so the
-    context is closed before advancing or suspending the iterator.
+    The creator has the same interface as :func:`warning_error_context`, with the
+    zero-based iteration index added as ``i``. It does not infer any other context
+    from the item. Enter it explicitly in the loop body so the context is closed
+    before advancing or suspending the iterator.
     """
-    for item in iterable:
-        yield warning_error_context, item
+    for i, item in enumerate(iterable):
+        yield _make_iteration_context_factory(i), item

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -72,7 +72,7 @@ def _add_note(exc: BaseException, note: str) -> None:
 
     notes = getattr(exc, "__notes__", [])
     notes.append(note)
-    exc.__notes__ = notes
+    setattr(exc, "__notes__", notes)
 
 
 @contextmanager

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from contextlib import AbstractContextManager, contextmanager
-from contextvars import ContextVar
+from contextlib import AbstractContextManager
+from contextvars import ContextVar, Token
 from copy import copy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Sequence
 
 T = TypeVar("T")
 
@@ -38,9 +38,8 @@ class WarningErrorContextRecord(NamedTuple):
     message: Union[Warning, BaseException, str]
 
 
-@dataclass
-class WarningErrorContext:
-    """The persistent result returned by :func:`warning_error_context`.
+class WarningErrorContext(AbstractContextManager["WarningErrorContext"]):
+    """A warning/error context and its persistent event records.
 
     Attributes
     ----------
@@ -50,10 +49,80 @@ class WarningErrorContext:
 
     """
 
-    records: list[WarningErrorContextRecord] = field(default_factory=list, init=False)
+    def __init__(
+        self,
+        name: str,
+        context: Optional[dict[str, Any]] = None,
+        *,
+        context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+        record_only: bool = False,
+    ) -> None:
+        self.records: list[WarningErrorContextRecord] = []
+        self._name = name
+        self._context = context
+        self._context_provider = context_provider
+        self._record_only = record_only
+        self._frame: Optional[_ContextFrame] = None
+        self._token: Optional[Token] = None
+        self._started = False
+
+    def start(self) -> WarningErrorContext:
+        """Activate the context and return this object.
+
+        Use the context-manager form when exceptions must be recorded and
+        annotated reliably.
+        """
+        if self._frame is not None:
+            raise RuntimeError("The warning/error context is already active.")
+        if self._started:
+            raise RuntimeError("The warning/error context cannot be restarted.")
+
+        frame = _ContextFrame(
+            name=self._name,
+            context=dict({} if self._context is None else self._context),
+            context_provider=self._context_provider,
+            result=self,
+            record_only=self._record_only,
+        )
+        self._token = _context_stack.set((*_context_stack.get(), frame))
+        self._frame = frame
+        self._started = True
+        return self
+
+    def stop(self) -> None:
+        """Deactivate the context without recording an exception."""
+        if self._frame is None or self._token is None:
+            raise RuntimeError("The warning/error context is not active.")
+        stack = _context_stack.get()
+        if not stack or stack[-1] is not self._frame:
+            raise RuntimeError("Nested warning/error contexts must be stopped in reverse order.")
+
+        is_outermost_context = len(stack) == 1
+        _context_stack.reset(self._token)
+        self._frame = None
+        self._token = None
+        if is_outermost_context:
+            _recorded_error.set(None)
+
+    def __enter__(self) -> WarningErrorContext:
+        return self.start()
+
+    def __exit__(self, _exc_type: Any, exc: Optional[BaseException], _traceback: Any) -> Optional[bool]:
+        frame = self._frame
+        if frame is None:
+            raise RuntimeError("The warning/error context is not active.")
+        try:
+            if exc is not None:
+                if _recorded_error.get() is not exc:
+                    _record_event("error", _render_context_stack(), exc)
+                    _recorded_error.set(exc)
+                _add_note(exc, f"Context: {frame.render()}")
+        finally:
+            self.stop()
+        return None
 
 
-_WarningErrorContextFactory = Callable[..., AbstractContextManager[WarningErrorContext]]
+_WarningErrorContextFactory = Callable[..., WarningErrorContext]
 
 
 def _safe_repr(value: Any) -> str:
@@ -65,6 +134,13 @@ def _safe_repr(value: Any) -> str:
 
 def _render_context_values(context: Mapping[str, Any]) -> str:
     return ", ".join(f"{key}={_safe_repr(value)}" for key, value in context.items())
+
+
+def _render_named_context(name: str, context: Mapping[str, Any]) -> str:
+    rendered_context = _render_context_values(context)
+    if not rendered_context:
+        return name
+    return f"{name}: {rendered_context}"
 
 
 def _safe_exception_description(exc: BaseException) -> str:
@@ -79,8 +155,8 @@ def _safe_exception_description(exc: BaseException) -> str:
 class _ContextFrame:
     name: str
     context: dict[str, Any]
+    result: WarningErrorContext
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None
-    result: WarningErrorContext = field(default_factory=WarningErrorContext)
     record_only: bool = False
 
     def _render_context(self) -> str:
@@ -105,9 +181,7 @@ class _ContextFrame:
 
     def render(self) -> str:
         rendered_context = self._render_context()
-        if not rendered_context:
-            return self.name
-        return f"{self.name}: {rendered_context}"
+        return self.name if not rendered_context else f"{self.name}: {rendered_context}"
 
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
@@ -133,7 +207,7 @@ def _is_record_only() -> bool:
 
 
 def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
-    return " > ".join(_ContextFrame(name=name, context=context).render() for name, context in contexts)
+    return " > ".join(_render_named_context(name, context) for name, context in contexts)
 
 
 def _warning_message_with_context(message: str, context: str) -> str:
@@ -249,7 +323,6 @@ def _add_note(exc: BaseException, note: str) -> None:
         pass
 
 
-@contextmanager
 def warning_error_context(
     name: str,
     context: Optional[dict[str, Any]] = None,
@@ -257,7 +330,7 @@ def warning_error_context(
     *,
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
     record_only: bool = False,
-) -> Generator[WarningErrorContext, None, None]:
+) -> WarningErrorContext:
     """Add structured context information to warnings and exceptions raised in the context.
 
     If provided, ``context`` is copied when the context is entered.
@@ -291,28 +364,12 @@ def warning_error_context(
     displayed by Python's standard traceback renderer. Traceback renderers that
     support exception notes, such as Rich, display this context on those versions.
     """
-    result = WarningErrorContext()
-    frame = _ContextFrame(
-        name=name,
-        context=dict({} if context is None else context),
+    return WarningErrorContext(
+        name,
+        context,
         context_provider=context_provider,
-        result=result,
         record_only=record_only,
     )
-    token = _context_stack.set((*_context_stack.get(), frame))
-    try:
-        yield result
-    except BaseException as exc:
-        if _recorded_error.get() is not exc:
-            _record_event("error", _render_context_stack(), exc)
-            _recorded_error.set(exc)
-        _add_note(exc, f"Context: {frame.render()}")
-        raise
-    finally:
-        is_outermost_context = len(_context_stack.get()) == 1
-        _context_stack.reset(token)
-        if is_outermost_context:
-            _recorded_error.set(None)
 
 
 def print_with_context(
@@ -356,7 +413,7 @@ def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
         record_only: bool = False,
-    ) -> AbstractContextManager[WarningErrorContext]:
+    ) -> WarningErrorContext:
         context = {} if context is None else context
         if "i" in context:
             raise ValueError("The context key 'i' is reserved by iter_with_warning_error_context.")

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -30,22 +30,31 @@ def _render_context_stack() -> str:
     return " > ".join(frame.render() for frame in _context_stack.get())
 
 
+def _warning_with_context(message: Warning, context: str) -> Warning:
+    contextualized_warning = type(message).__new__(type(message))
+    contextualized_warning.__dict__.update(getattr(message, "__dict__", {}))
+    contextualized_warning.args = (f"[{context}] {message}", *message.args[1:])
+    return contextualized_warning
+
+
 def _warn_with_context(
     message: Union[Warning, str],
     category: Optional[type[Warning]] = None,
     stacklevel: int = 1,
     source: Any = None,
+    **kwargs: Any,
 ) -> None:
     context = _render_context_stack()
     if not context:
-        _warn(message, category=category, stacklevel=stacklevel, source=source)
+        _warn(message, category=category, stacklevel=stacklevel, source=source, **kwargs)
         return
 
     if isinstance(message, Warning):
-        category = category or type(message)
-        message = str(message)
+        message_with_context = _warning_with_context(message, context)
+    else:
+        message_with_context = f"[{context}] {message}"
 
-    _warn(f"[{context}] {message}", category=category, stacklevel=stacklevel + 1, source=source)
+    _warn(message_with_context, category=category, stacklevel=stacklevel + 1, source=source, **kwargs)
 
 
 warnings.warn = _warn_with_context

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Mapping
-from contextlib import contextmanager
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from copy import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
+
+T = TypeVar("T")
+_WarningErrorContextFactory = Callable[..., AbstractContextManager[None]]
 
 
 @dataclass(frozen=True)
@@ -166,6 +169,10 @@ def warning_error_context(
 
     A failing provider is represented in the rendered context instead of masking the
     warning or exception that caused context rendering.
+
+    On Python 3.9 and 3.10, exception context is stored in ``__notes__`` but is not
+    displayed by Python's standard traceback renderer. Traceback renderers that
+    support exception notes, such as Rich, display this context on those versions.
     """
     frame = _ContextFrame(name=name, metadata=metadata, metadata_provider=metadata_provider)
     token = _context_stack.set((*_context_stack.get(), frame))
@@ -176,3 +183,16 @@ def warning_error_context(
         raise
     finally:
         _context_stack.reset(token)
+
+
+def iter_with_warning_error_context(
+    iterable: Iterable[T],
+) -> Iterator[tuple[_WarningErrorContextFactory, T]]:
+    """Pair every item with a warning/error context creator.
+
+    The creator has the same interface as :func:`warning_error_context` and does
+    not infer metadata from the item. Enter it explicitly in the loop body so the
+    context is closed before advancing or suspending the iterator.
+    """
+    for item in iterable:
+        yield warning_error_context, item

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from contextlib import contextmanager
 from contextvars import ContextVar
+from copy import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -23,7 +24,6 @@ class _ContextFrame:
 
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
-_warn = warnings.warn
 
 
 def _render_context_stack() -> str:
@@ -35,33 +35,85 @@ def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
 
 
 def _warning_with_context(message: Warning, context: str) -> Warning:
-    contextualized_warning = type(message).__new__(type(message))
+    # Calling the concrete type's constructor is not safe: warning subclasses can
+    # require extra arguments in __new__. BaseException can allocate every Warning
+    # subtype without invoking the subtype's constructor.
+    contextualized_warning = BaseException.__new__(type(message))
     contextualized_warning.__dict__.update(getattr(message, "__dict__", {}))
+    for base_class in type(message).__mro__:
+        slots = base_class.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot_name in slots:
+            if slot_name in {"__dict__", "__weakref__"}:
+                continue
+            actual_slot_name = slot_name
+            if slot_name.startswith("__") and not slot_name.endswith("__"):
+                actual_slot_name = f"_{base_class.__name__.lstrip('_')}{slot_name}"
+            slot_descriptor = base_class.__dict__[actual_slot_name]
+            try:
+                slot_value = slot_descriptor.__get__(message, type(message))
+            except AttributeError:
+                continue
+            slot_descriptor.__set__(contextualized_warning, slot_value)
     contextualized_warning.args = (f"[{context}] {message}", *message.args[1:])
     return contextualized_warning
 
 
-def _warn_with_context(
-    message: Union[Warning, str],
-    category: Optional[type[Warning]] = None,
-    stacklevel: int = 1,
-    source: Any = None,
-    **kwargs: Any,
-) -> None:
+def _contextualize_warning(message: Union[Warning, str]) -> Union[Warning, str]:
     context = _render_context_stack()
     if not context:
-        _warn(message, category=category, stacklevel=stacklevel + 1, source=source, **kwargs)
-        return
-
-    if isinstance(message, Warning):
-        message_with_context = _warning_with_context(message, context)
-    else:
-        message_with_context = f"[{context}] {message}"
-
-    _warn(message_with_context, category=category, stacklevel=stacklevel + 1, source=source, **kwargs)
+        return message
+    if isinstance(message, str):
+        return f"[{context}] {message}"
+    return _warning_with_context(message, context)
 
 
-warnings.warn = _warn_with_context
+_TPCP_DISPATCHER_MARKER = "_tpcp_warning_context_dispatcher"
+_TPCP_ORIGINAL_DISPATCHER = "_tpcp_warning_context_original_dispatcher"
+
+_installed_showwarnmsg = getattr(warnings, "_showwarnmsg", None)
+if getattr(_installed_showwarnmsg, _TPCP_DISPATCHER_MARKER, False):
+    # Module reloads must unwrap our existing dispatcher instead of chaining it
+    # again. Otherwise the old function resolves reloaded module globals and recurses.
+    _original_showwarnmsg = getattr(_installed_showwarnmsg, _TPCP_ORIGINAL_DISPATCHER)
+else:
+    _original_showwarnmsg = _installed_showwarnmsg
+_original_showwarning = warnings.showwarning
+
+
+def _showwarnmsg_with_context(message: warnings.WarningMessage) -> None:
+    """Add active context before forwarding a warning to Python's dispatcher."""
+    if _context_stack.get():
+        message = copy(message)
+        message.message = _contextualize_warning(message.message)
+
+    # Patch this private dispatcher intentionally: warnings.warn misses aliases
+    # imported earlier, warn_explicit, and C warnings, while showwarning is bypassed
+    # by catch_warnings(record=True) and pytest.warns. Forwarding the WarningMessage
+    # exactly once avoids re-filtering, recursion, and distorted source locations.
+    original_showwarnmsg = getattr(_showwarnmsg_with_context, _TPCP_ORIGINAL_DISPATCHER)
+    original_showwarnmsg(message)
+
+
+if callable(_original_showwarnmsg):
+    setattr(_showwarnmsg_with_context, _TPCP_DISPATCHER_MARKER, True)
+    setattr(_showwarnmsg_with_context, _TPCP_ORIGINAL_DISPATCHER, _original_showwarnmsg)
+    setattr(warnings, "_showwarnmsg", _showwarnmsg_with_context)
+else:
+
+    def _showwarning_with_context(
+        message: Warning,
+        category: type[Warning],
+        filename: str,
+        lineno: int,
+        file: Any = None,
+        line: Optional[str] = None,
+    ) -> None:
+        """Fallback for Python implementations without warnings._showwarnmsg."""
+        _original_showwarning(_contextualize_warning(message), category, filename, lineno, file, line)
+
+    warnings.showwarning = _showwarning_with_context
 
 
 def _add_note(exc: BaseException, note: str) -> None:

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from copy import copy
@@ -15,12 +16,33 @@ if TYPE_CHECKING:
 class _ContextFrame:
     name: str
     metadata: dict[str, Any]
+    metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None
+
+    def _render_metadata(self) -> str:
+        metadata = self.metadata
+        if self.metadata_provider is not None:
+            try:
+                provided_metadata = self.metadata_provider()
+                if not isinstance(provided_metadata, Mapping):
+                    raise TypeError("metadata_provider must return a mapping")
+                duplicate_keys = metadata.keys() & provided_metadata.keys()
+                if duplicate_keys:
+                    duplicates = ", ".join(sorted(duplicate_keys))
+                    raise ValueError(f"metadata_provider returned duplicate keys: {duplicates}")
+                metadata = {**metadata, **provided_metadata}
+            except BaseException as exc:  # noqa: BLE001 - context rendering must not mask the original event
+                provider_error = f"{type(exc).__name__}: {exc}"
+                rendered_metadata = ", ".join(f"{key}={value!r}" for key, value in metadata.items())
+                rendered_error = f"metadata_provider_error={provider_error!r}"
+                return ", ".join(filter(None, (rendered_metadata, rendered_error)))
+
+        return ", ".join(f"{key}={value!r}" for key, value in metadata.items())
 
     def render(self) -> str:
-        if not self.metadata:
+        rendered_metadata = self._render_metadata()
+        if not rendered_metadata:
             return self.name
-        metadata = ", ".join(f"{key}={value!r}" for key, value in self.metadata.items())
-        return f"{self.name}: {metadata}"
+        return f"{self.name}: {rendered_metadata}"
 
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
@@ -128,9 +150,24 @@ def _add_note(exc: BaseException, note: str) -> None:
 
 
 @contextmanager
-def warning_error_context(name: str, /, **metadata: Any) -> Generator[None, None, None]:
-    """Add structured context information to warnings and exceptions raised in the context."""
-    frame = _ContextFrame(name=name, metadata=metadata)
+def warning_error_context(
+    name: str,
+    /,
+    *,
+    metadata_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
+    **metadata: Any,
+) -> Generator[None, None, None]:
+    """Add structured context information to warnings and exceptions raised in the context.
+
+    ``metadata`` values are fixed when the context is entered. ``metadata_provider``
+    is evaluated whenever context is rendered, allowing diagnostics to include state
+    that changes while the context is active. The provider must return a mapping and
+    must not repeat fixed metadata keys.
+
+    A failing provider is represented in the rendered context instead of masking the
+    warning or exception that caused context rendering.
+    """
+    frame = _ContextFrame(name=name, metadata=metadata, metadata_provider=metadata_provider)
     token = _context_stack.set((*_context_stack.get(), frame))
     try:
         yield

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -5,14 +5,54 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from copy import copy
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
 
 T = TypeVar("T")
-_WarningErrorContextFactory = Callable[..., AbstractContextManager[None]]
+
+
+class WarningErrorContextRecord(NamedTuple):
+    """A warning, error, or contextual print captured by an active context.
+
+    The original warning or exception object is retained as ``message`` so its
+    concrete type and custom attributes remain available for later inspection.
+    Contextual prints store their unmodified rendered text.
+
+    Attributes
+    ----------
+    type
+        The kind of captured event.
+    context
+        The fully rendered context stack at the time of the event.
+    message
+        The original warning or exception object, or the rendered print text.
+
+    """
+
+    type: Literal["warning", "error", "print"]
+    context: str
+    message: Union[Warning, BaseException, str]
+
+
+@dataclass
+class WarningErrorContext:
+    """The persistent result returned by :func:`warning_error_context`.
+
+    Attributes
+    ----------
+    records
+        Events observed while the context was active. Events from nested contexts
+        are included with their fully rendered context stack.
+
+    """
+
+    records: list[WarningErrorContextRecord] = field(default_factory=list, init=False)
+
+
+_WarningErrorContextFactory = Callable[..., AbstractContextManager[WarningErrorContext]]
 
 
 def _safe_repr(value: Any) -> str:
@@ -39,6 +79,7 @@ class _ContextFrame:
     name: str
     context: dict[str, Any]
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None
+    result: WarningErrorContext = field(default_factory=WarningErrorContext)
 
     def _render_context(self) -> str:
         context = self.context
@@ -68,10 +109,21 @@ class _ContextFrame:
 
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
+_recorded_error: ContextVar[Optional[BaseException]] = ContextVar("tpcp_warning_error_recorded_error", default=None)
 
 
 def _render_context_stack() -> str:
     return " > ".join(frame.render() for frame in _context_stack.get())
+
+
+def _record_event(
+    event_type: Literal["warning", "error", "print"],
+    context: str,
+    message: Union[Warning, BaseException, str],
+) -> None:
+    record = WarningErrorContextRecord(event_type, context, message)
+    for frame in _context_stack.get():
+        frame.result.records.append(record)
 
 
 def _render_contexts(contexts: Sequence[tuple[str, dict[str, Any]]]) -> str:
@@ -108,8 +160,8 @@ def _warning_with_context(message: Warning, context: str) -> Warning:
     return contextualized_warning
 
 
-def _contextualize_warning(message: Union[Warning, str]) -> Union[Warning, str]:
-    context = _render_context_stack()
+def _contextualize_warning(message: Union[Warning, str], context: Optional[str] = None) -> Union[Warning, str]:
+    context = _render_context_stack() if context is None else context
     if not context:
         return message
     if isinstance(message, str):
@@ -133,8 +185,10 @@ _original_showwarning = warnings.showwarning
 def _showwarnmsg_with_context(message: warnings.WarningMessage) -> None:
     """Add active context before forwarding a warning to Python's dispatcher."""
     if _context_stack.get():
+        context = _render_context_stack()
+        _record_event("warning", context, message.message)
         message = copy(message)
-        message.message = _contextualize_warning(message.message)
+        message.message = _contextualize_warning(message.message, context)
 
     # Patch this private dispatcher intentionally: warnings.warn misses aliases
     # imported earlier, warn_explicit, and C warnings, while showwarning is bypassed
@@ -159,7 +213,10 @@ else:
         line: Optional[str] = None,
     ) -> None:
         """Fallback for Python implementations without warnings._showwarnmsg."""
-        _original_showwarning(_contextualize_warning(message), category, filename, lineno, file, line)
+        context = _render_context_stack()
+        if context:
+            _record_event("warning", context, message)
+        _original_showwarning(_contextualize_warning(message, context), category, filename, lineno, file, line)
 
     warnings.showwarning = _showwarning_with_context
 
@@ -189,7 +246,7 @@ def warning_error_context(
     /,
     *,
     context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
-) -> Generator[None, None, None]:
+) -> Generator[WarningErrorContext, None, None]:
     """Add structured context information to warnings and exceptions raised in the context.
 
     If provided, ``context`` is copied when the context is entered.
@@ -206,21 +263,37 @@ def warning_error_context(
     count as distinct occurrences. If every contextual occurrence must be shown, use
     an appropriate warning filter such as ``warnings.simplefilter("always")``.
 
+    The context manager yields a :class:`WarningErrorContext` whose ``records`` list
+    remains available after the context exits. It contains warnings that reached
+    Python's warning dispatcher and exceptions that escaped the context. Original
+    warning and exception objects are retained so callers can inspect their concrete
+    types and custom attributes.
+
     On Python 3.9 and 3.10, exception context is stored in ``__notes__`` but is not
     displayed by Python's standard traceback renderer. Traceback renderers that
     support exception notes, such as Rich, display this context on those versions.
     """
+    result = WarningErrorContext()
     frame = _ContextFrame(
-        name=name, context=dict({} if context is None else context), context_provider=context_provider
+        name=name,
+        context=dict({} if context is None else context),
+        context_provider=context_provider,
+        result=result,
     )
     token = _context_stack.set((*_context_stack.get(), frame))
     try:
-        yield
+        yield result
     except BaseException as exc:
+        if _recorded_error.get() is not exc:
+            _record_event("error", _render_context_stack(), exc)
+            _recorded_error.set(exc)
         _add_note(exc, f"Context: {frame.render()}")
         raise
     finally:
+        is_outermost_context = len(_context_stack.get()) == 1
         _context_stack.reset(token)
+        if is_outermost_context:
+            _recorded_error.set(None)
 
 
 def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
@@ -230,7 +303,7 @@ def _make_iteration_context_factory(i: int) -> _WarningErrorContextFactory:
         /,
         *,
         context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
-    ) -> AbstractContextManager[None]:
+    ) -> AbstractContextManager[WarningErrorContext]:
         context = {} if context is None else context
         if "i" in context:
             raise ValueError("The context key 'i' is reserved by iter_with_warning_error_context.")

--- a/src/tpcp/optimize/_optimize.py
+++ b/src/tpcp/optimize/_optimize.py
@@ -406,9 +406,7 @@ class GridSearch(BaseOptimize[PipelineT, DatasetT], Generic[PipelineT, DatasetT]
                             return_parameters=True,
                             return_data_labels=True,
                             return_times=True,
-                            context=(
-                                ("parameter_candidate", {"index": candidate_index, "parameters": paras}),
-                            ),
+                            context=(("parameter_candidate", {"index": candidate_index, "parameters": paras}),),
                         )
                         for candidate_index, paras in enumerate(self.parameter_grid)
                     )

--- a/src/tpcp/optimize/_optimize.py
+++ b/src/tpcp/optimize/_optimize.py
@@ -406,9 +406,11 @@ class GridSearch(BaseOptimize[PipelineT, DatasetT], Generic[PipelineT, DatasetT]
                             return_parameters=True,
                             return_data_labels=True,
                             return_times=True,
-                            error_info=f"This error occurred for the following parameter:\n\n{paras}",
+                            context=(
+                                ("parameter_candidate", {"index": candidate_index, "parameters": paras}),
+                            ),
                         )
-                        for paras in self.parameter_grid
+                        for candidate_index, paras in enumerate(self.parameter_grid)
                     )
                 )
             )
@@ -784,8 +786,13 @@ class GridSearchCV(
                                 return_data_labels=True,
                                 return_times=True,
                                 memory=tmp_cache,
-                                error_info=f"This error occurred in fold {split_idx} with parameters candidate "
-                                f"{cand_idx}.",
+                                context=(
+                                    (
+                                        "parameter_candidate",
+                                        {"index": cand_idx, "parameters": parameters[cand_idx]},
+                                    ),
+                                    ("cv_fold", {"index": split_idx}),
+                                ),
                             )
                             for (cand_idx, (hyper_paras, pure_paras)), (
                                 split_idx,

--- a/src/tpcp/optimize/optuna.py
+++ b/src/tpcp/optimize/optuna.py
@@ -287,7 +287,13 @@ class _CustomOptunaOptimize(BaseOptimize[PipelineT, DatasetT]):
 
         def objective(trial: Trial):
             inner_pipe = clone(pipeline)
-            with warning_error_context("optuna_trial", number=trial.number, params=trial.params):
+            with warning_error_context(
+                "optuna_trial",
+                number=trial.number,
+                # Optuna returns a snapshot here, and only populates it as the objective calls suggest_*.
+                # Resolve it when a warning or exception occurs so the context reflects the parameters known then.
+                metadata_provider=lambda: {"params": trial.params},
+            ):
                 return inner_objective(trial, inner_pipe, dataset)
 
         return objective

--- a/src/tpcp/optimize/optuna.py
+++ b/src/tpcp/optimize/optuna.py
@@ -289,10 +289,10 @@ class _CustomOptunaOptimize(BaseOptimize[PipelineT, DatasetT]):
             inner_pipe = clone(pipeline)
             with warning_error_context(
                 "optuna_trial",
-                number=trial.number,
+                {"number": trial.number},
                 # Optuna returns a snapshot here, and only populates it as the objective calls suggest_*.
                 # Resolve it when a warning or exception occurs so the context reflects the parameters known then.
-                metadata_provider=lambda: {"params": trial.params},
+                context_provider=lambda: {"params": trial.params},
             ):
                 return inner_objective(trial, inner_pipe, dataset)
 

--- a/src/tpcp/optimize/optuna.py
+++ b/src/tpcp/optimize/optuna.py
@@ -26,6 +26,7 @@ from tpcp import OptimizablePipeline, clone
 from tpcp._dataset import DatasetT
 from tpcp._optimize import BaseOptimize
 from tpcp._pipeline import PipelineT
+from tpcp.misc import warning_error_context
 from tpcp.optimize import Optimize
 from tpcp.parallel import delayed
 from tpcp.validate._scorer import ScorerTypes, _validate_scorer
@@ -286,7 +287,8 @@ class _CustomOptunaOptimize(BaseOptimize[PipelineT, DatasetT]):
 
         def objective(trial: Trial):
             inner_pipe = clone(pipeline)
-            return inner_objective(trial, inner_pipe, dataset)
+            with warning_error_context("optuna_trial", number=trial.number, params=trial.params):
+                return inner_objective(trial, inner_pipe, dataset)
 
         return objective
 

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
 from collections import defaultdict
 from functools import partial
 from typing import (
@@ -28,6 +27,7 @@ from tpcp._hash import custom_hash
 from tpcp._pipeline import PipelineT
 from tpcp._utils._general import _passthrough
 from tpcp.exceptions import ScorerFailedError, ValidationError
+from tpcp.misc import warning_error_context
 from tpcp.parallel import delayed
 
 if TYPE_CHECKING:
@@ -410,15 +410,12 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
         def per_datapoint(i, d):
             try:
                 # We need to clone here again, to make sure that the run for each data point is truly independent.
-                score = self.score_func(pipeline.clone(), d)
+                with warning_error_context("datapoint", index=i, group_label=d.group_label):
+                    score = self.score_func(pipeline.clone(), d)
             except Exception as e:
                 raise ScorerFailedError(
-                    f"Scorer raised an exception while scoring data point {i} ({d.group_label}). "
-                    "Tpcp does not support that (compared to sklearn) and you need to handle error cases yourself "
-                    "within the scoring function."
-                    "\n\n"
-                    "The original exception was:\n\n"
-                    f"{traceback.format_exc()}"
+                    "Scorer failed while scoring a datapoint. "
+                    "Handle expected error cases inside the scoring function."
                 ) from e
             return i, score
 

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -414,7 +414,7 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
                 # We need to clone here again, to make sure that the run for each data point is truly independent.
                 group_label = d.group_label
                 group_label_available = True
-                with warning_error_context("datapoint", index=i, group_label=group_label):
+                with warning_error_context("datapoint", {"index": i, "group_label": group_label}):
                     score = self.score_func(pipeline.clone(), d)
             except Exception as e:
                 group_label_display = "<unavailable>"

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -414,7 +414,7 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
                     score = self.score_func(pipeline.clone(), d)
             except Exception as e:
                 raise ScorerFailedError(
-                    "Scorer failed while scoring a datapoint. "
+                    f"Scorer failed while scoring datapoint {i} ({d.group_label}). "
                     "Handle expected error cases inside the scoring function."
                 ) from e
             return i, score

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -408,13 +408,23 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
 
     def _score(self, pipeline: PipelineT, dataset: DatasetT):
         def per_datapoint(i, d):
+            group_label = None
+            group_label_available = False
             try:
                 # We need to clone here again, to make sure that the run for each data point is truly independent.
-                with warning_error_context("datapoint", index=i, group_label=d.group_label):
+                group_label = d.group_label
+                group_label_available = True
+                with warning_error_context("datapoint", index=i, group_label=group_label):
                     score = self.score_func(pipeline.clone(), d)
             except Exception as e:
+                group_label_display = "<unavailable>"
+                if group_label_available:
+                    try:
+                        group_label_display = str(group_label)
+                    except BaseException:  # noqa: BLE001 - diagnostics must not replace the scoring error
+                        group_label_display = f"<unrenderable {type(group_label).__name__}>"
                 raise ScorerFailedError(
-                    "Scorer failed while scoring a datapoint. "
+                    f"Scorer failed while scoring datapoint {i} ({group_label_display}). "
                     "Handle expected error cases inside the scoring function."
                 ) from e
             return i, score

--- a/src/tpcp/validate/_validate.py
+++ b/src/tpcp/validate/_validate.py
@@ -140,7 +140,7 @@ def cross_validate(
                         return_times=True,
                         return_data_labels=True,
                         return_optimizer=return_optimizer,
-                        error_info=f"This error occurred in fold {i}.",
+                        context=(("cv_fold", {"index": i}),),
                     )
                     for i, (train, test) in enumerate(splits)
                 )

--- a/tests/test_examples/test_all_examples.py
+++ b/tests/test_examples/test_all_examples.py
@@ -192,3 +192,8 @@ def test_pretrained_models_example():
     from examples.recipies._06_pretrained_models import algo_with_clean_lab_model
 
     assert algo_with_clean_lab_model.model == "model_clean_lab_data"
+
+
+def test_warning_error_context_example():
+    # Import the gallery example to ensure that it executes without errors.
+    import examples.recipies._07_warning_error_context  # noqa: F401

--- a/tests/test_misc/test_typed_iterator.py
+++ b/tests/test_misc/test_typed_iterator.py
@@ -87,15 +87,40 @@ def test_iterator_body_warning_contains_iteration_context():
     rt = make_dataclass("ResultType", ["result"])
     iterator = TypedIterator(rt)
 
+    def emit_iteration_warning():
+        for data_point, result in iterator.iterate([1]):
+            with iterator.warning_error_context(
+                "typed_iterator_iteration",
+                iteration_name="__main__",
+                input=data_point,
+                iteration_context={},
+            ):
+                warnings.warn("iteration warning", UserWarning, stacklevel=1)
+                result.result = 1
+
     with pytest.warns(
         UserWarning,
         match=re.escape(
             "[typed_iterator_iteration: iteration_name='__main__', input=1, iteration_context={}] iteration warning"
         ),
     ):
-        for _, result in iterator.iterate([1]):
-            warnings.warn("iteration warning", UserWarning, stacklevel=1)
-            result.result = 1
+        emit_iteration_warning()
+
+
+def test_iterator_body_exception_contains_explicit_context():
+    """The explicit iterator context annotates errors raised by the loop body."""
+    rt = make_dataclass("ResultType", ["result"])
+    iterator = TypedIterator(rt)
+
+    def raise_iteration_error():
+        for data_point, _ in iterator.iterate([1]):
+            with iterator.warning_error_context("typed_iterator", input=data_point, stage="processing"):
+                raise ValueError("iteration error")
+
+    with pytest.raises(ValueError, match="iteration error") as error:
+        raise_iteration_error()
+
+    assert error.value.__notes__ == ["Context: typed_iterator: input=1, stage='processing'"]
 
 
 def test_additional_aggregations():

--- a/tests/test_misc/test_typed_iterator.py
+++ b/tests/test_misc/test_typed_iterator.py
@@ -1,3 +1,5 @@
+import re
+import warnings
 from dataclasses import fields, make_dataclass
 
 import pytest
@@ -79,6 +81,21 @@ def test_warning_incomplete_iterate():
         partial_results = iterator.results_.result_1
 
     assert partial_results == [TypedIterator.NULL_VALUE]
+
+
+def test_iterator_body_warning_contains_iteration_context():
+    rt = make_dataclass("ResultType", ["result"])
+    iterator = TypedIterator(rt)
+
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "[typed_iterator_iteration: iteration_name='__main__', input=1, iteration_context={}] iteration warning"
+        ),
+    ):
+        for _, result in iterator.iterate([1]):
+            warnings.warn("iteration warning", UserWarning, stacklevel=1)
+            result.result = 1
 
 
 def test_additional_aggregations():

--- a/tests/test_misc/test_typed_iterator.py
+++ b/tests/test_misc/test_typed_iterator.py
@@ -137,7 +137,7 @@ def test_iterator_context_provider_does_not_require_fixed_context():
     with pytest.warns(UserWarning) as caught:
         emit_warning()
 
-    assert str(caught[0].message) == "[typed_iterator: i=0, input=1] provider-only warning"
+    assert str(caught[0].message) == "provider-only warning\n[typed_iterator: i=0, input=1] provider-only warning"
 
 
 def test_additional_aggregations():

--- a/tests/test_misc/test_typed_iterator.py
+++ b/tests/test_misc/test_typed_iterator.py
@@ -122,44 +122,22 @@ def test_iterator_body_exception_contains_explicit_context():
     assert error.value.__notes__ == ["Context: typed_iterator: i=0, input=1, stage='processing'"]
 
 
-def test_iterator_context_injects_and_restores_nested_iteration_indices():
-    """Nested TypedIterator loops receive their respective current indices."""
+def test_iterator_context_provider_does_not_require_fixed_context():
+    """The TypedIterator helper supports provider-only context plus its injected index."""
     rt = make_dataclass("ResultType", ["result"])
     iterator = TypedIterator(rt)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        for outer_data, _ in iterator.iterate([10]):
-            with iterator.warning_error_context("outer", {"input": outer_data}):
-                warnings.warn("outer before", UserWarning, stacklevel=1)
-            for inner_data, _ in iterator._iterate([20, 21], iteration_name="inner"):
-                with iterator.warning_error_context("inner", {"input": inner_data}):
-                    warnings.warn("inner", UserWarning, stacklevel=1)
-            with iterator.warning_error_context("outer", {"input": outer_data}):
-                warnings.warn("outer after", UserWarning, stacklevel=1)
+    def emit_warning():
+        for data_point, _ in iterator.iterate([1]):
+            with iterator.warning_error_context(
+                "typed_iterator", context_provider=lambda data_point=data_point: {"input": data_point}
+            ):
+                warnings.warn("provider-only warning", UserWarning, stacklevel=1)
 
-    assert [str(warning.message) for warning in caught] == [
-        "[outer: i=0, input=10] outer before",
-        "[inner: i=0, input=20] inner",
-        "[inner: i=1, input=21] inner",
-        "[outer: i=0, input=10] outer after",
-    ]
+    with pytest.warns(UserWarning) as caught:
+        emit_warning()
 
-
-def test_iterator_context_is_only_available_in_an_active_loop_body():
-    """The injected index is scoped to the currently yielded iteration."""
-    rt = make_dataclass("ResultType", ["result"])
-    iterator = TypedIterator(rt)
-
-    with pytest.raises(RuntimeError, match="inside an active TypedIterator loop body"):
-        iterator.warning_error_context("outside", {})
-
-    for _, _ in iterator.iterate([1]):
-        with iterator.warning_error_context("inside", {}):
-            pass
-
-    with pytest.raises(RuntimeError, match="inside an active TypedIterator loop body"):
-        iterator.warning_error_context("outside", {})
+    assert str(caught[0].message) == "[typed_iterator: i=0, input=1] provider-only warning"
 
 
 def test_additional_aggregations():

--- a/tests/test_misc/test_typed_iterator.py
+++ b/tests/test_misc/test_typed_iterator.py
@@ -91,9 +91,7 @@ def test_iterator_body_warning_contains_iteration_context():
         for data_point, result in iterator.iterate([1]):
             with iterator.warning_error_context(
                 "typed_iterator_iteration",
-                iteration_name="__main__",
-                input=data_point,
-                iteration_context={},
+                {"iteration_name": "__main__", "input": data_point, "iteration_context": {}},
             ):
                 warnings.warn("iteration warning", UserWarning, stacklevel=1)
                 result.result = 1
@@ -101,7 +99,8 @@ def test_iterator_body_warning_contains_iteration_context():
     with pytest.warns(
         UserWarning,
         match=re.escape(
-            "[typed_iterator_iteration: iteration_name='__main__', input=1, iteration_context={}] iteration warning"
+            "[typed_iterator_iteration: i=0, iteration_name='__main__', input=1, iteration_context={}] "
+            "iteration warning"
         ),
     ):
         emit_iteration_warning()
@@ -114,13 +113,53 @@ def test_iterator_body_exception_contains_explicit_context():
 
     def raise_iteration_error():
         for data_point, _ in iterator.iterate([1]):
-            with iterator.warning_error_context("typed_iterator", input=data_point, stage="processing"):
+            with iterator.warning_error_context("typed_iterator", {"input": data_point, "stage": "processing"}):
                 raise ValueError("iteration error")
 
     with pytest.raises(ValueError, match="iteration error") as error:
         raise_iteration_error()
 
-    assert error.value.__notes__ == ["Context: typed_iterator: input=1, stage='processing'"]
+    assert error.value.__notes__ == ["Context: typed_iterator: i=0, input=1, stage='processing'"]
+
+
+def test_iterator_context_injects_and_restores_nested_iteration_indices():
+    """Nested TypedIterator loops receive their respective current indices."""
+    rt = make_dataclass("ResultType", ["result"])
+    iterator = TypedIterator(rt)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for outer_data, _ in iterator.iterate([10]):
+            with iterator.warning_error_context("outer", {"input": outer_data}):
+                warnings.warn("outer before", UserWarning, stacklevel=1)
+            for inner_data, _ in iterator._iterate([20, 21], iteration_name="inner"):
+                with iterator.warning_error_context("inner", {"input": inner_data}):
+                    warnings.warn("inner", UserWarning, stacklevel=1)
+            with iterator.warning_error_context("outer", {"input": outer_data}):
+                warnings.warn("outer after", UserWarning, stacklevel=1)
+
+    assert [str(warning.message) for warning in caught] == [
+        "[outer: i=0, input=10] outer before",
+        "[inner: i=0, input=20] inner",
+        "[inner: i=1, input=21] inner",
+        "[outer: i=0, input=10] outer after",
+    ]
+
+
+def test_iterator_context_is_only_available_in_an_active_loop_body():
+    """The injected index is scoped to the currently yielded iteration."""
+    rt = make_dataclass("ResultType", ["result"])
+    iterator = TypedIterator(rt)
+
+    with pytest.raises(RuntimeError, match="inside an active TypedIterator loop body"):
+        iterator.warning_error_context("outside", {})
+
+    for _, _ in iterator.iterate([1]):
+        with iterator.warning_error_context("inside", {}):
+            pass
+
+    with pytest.raises(RuntimeError, match="inside an active TypedIterator loop body"):
+        iterator.warning_error_context("outside", {})
 
 
 def test_additional_aggregations():

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -13,7 +13,10 @@ from joblib.externals import cloudpickle
 
 _warn_alias_imported_before_tpcp = warnings.warn
 
-from tpcp.misc import warning_error_context  # noqa: E402  (import must happen after capturing warnings.warn)
+from tpcp.misc import (  # noqa: E402  (import must happen after capturing warnings.warn)
+    iter_with_warning_error_context,
+    warning_error_context,
+)
 
 
 class _CustomWarning(UserWarning):
@@ -71,6 +74,25 @@ def test_nested_contexts_are_added_to_exception_notes():
     assert error.value.__notes__ == [
         "Context: region: start=10, end=20",
         "Context: datapoint: group='patient-1'",
+    ]
+
+
+def test_iter_with_warning_error_context_scopes_nested_loop_bodies():
+    """Iterator contexts nest explicitly and do not leak after a loop body."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for make_outer_context, outer_item in iter_with_warning_error_context([1]):
+            with make_outer_context("outer", item=outer_item):
+                for make_inner_context, inner_item in iter_with_warning_error_context([2]):
+                    with make_inner_context("inner", item=inner_item):
+                        warnings.warn("inner warning", UserWarning, stacklevel=1)
+                warnings.warn("outer warning", UserWarning, stacklevel=1)
+        warnings.warn("unscoped warning", UserWarning, stacklevel=1)
+
+    assert [str(warning.message) for warning in caught] == [
+        "[outer: item=1 > inner: item=2] inner warning",
+        "[outer: item=1] outer warning",
+        "unscoped warning",
     ]
 
 

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -2,6 +2,7 @@
 
 import _warnings
 import inspect
+import io
 import re
 import subprocess
 import sys
@@ -16,6 +17,7 @@ _warn_alias_imported_before_tpcp = warnings.warn
 from tpcp.misc import (  # noqa: E402  (import must happen after capturing warnings.warn)
     WarningErrorContextRecord,
     iter_with_warning_error_context,
+    print_with_context,
     warning_error_context,
 )
 
@@ -127,6 +129,81 @@ def test_context_records_warnings_and_errors_with_their_final_context():
     ]
     assert dataset_context.records == expected_records
     assert item_context.records == expected_records
+
+
+def test_print_with_context_prints_and_records_like_print():
+    """Contextual prints retain normal value, separator, terminator, and file handling."""
+    output = io.StringIO()
+
+    with warning_error_context("item", {"i": 3}) as context:
+        print_with_context("value", 5, sep="=", end="!", file=output, flush=True)
+
+    assert output.getvalue() == "[item: i=3] value=5!"
+    assert context.records == [WarningErrorContextRecord("print", "item: i=3", "value=5")]
+
+
+def test_print_with_context_without_active_context_is_a_normal_print():
+    """The print helper remains useful when no diagnostic context is active."""
+    output = io.StringIO()
+
+    print_with_context("plain", "output", file=output)
+
+    assert output.getvalue() == "plain output\n"
+
+
+def test_record_only_context_suppresses_contextual_output_but_records_all_events(capsys):
+    """A highest-level record-only context provides a quiet diagnostic event log."""
+    original_warning = UserWarning("signal is short")
+    original_error = ValueError("invalid signal")
+
+    try:
+        with (
+            warnings.catch_warnings(record=True) as emitted_warnings,
+            warning_error_context("program", {"run": 1}, record_only=True) as program_context,
+            warning_error_context("item", {"i": 3}) as item_context,
+        ):
+            warnings.simplefilter("always")
+            warnings.warn(original_warning, stacklevel=1)
+            print_with_context("processed", 3)
+            print("ordinary output")
+            raise original_error
+    except ValueError:
+        pass
+    else:
+        pytest.fail("The original error was not re-raised.")
+
+    expected_context = "program: run=1 > item: i=3"
+    expected_records = [
+        WarningErrorContextRecord("warning", expected_context, original_warning),
+        WarningErrorContextRecord("print", expected_context, "processed 3"),
+        WarningErrorContextRecord("error", expected_context, original_error),
+    ]
+    assert emitted_warnings == []
+    assert capsys.readouterr().out == "ordinary output\n"
+    assert program_context.records == expected_records
+    assert item_context.records == expected_records
+
+
+def test_record_only_print_rejects_an_invalid_end_value():
+    """Quiet contextual printing retains normal print argument validation."""
+    with (
+        warning_error_context("program", record_only=True) as program_context,
+        pytest.raises(TypeError, match="end must be None or a string"),
+    ):
+        print_with_context("message", end=1)
+
+    assert program_context.records == []
+
+
+def test_record_only_print_validates_sep_before_end():
+    """Contextual printing matches normal print validation order."""
+    with (
+        warning_error_context("program", record_only=True) as program_context,
+        pytest.raises(TypeError, match="sep must be None or a string"),
+    ):
+        print_with_context("message", sep=1, end=1)
+
+    assert program_context.records == []
 
 
 def test_failing_add_note_does_not_mask_exception():

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -91,6 +91,24 @@ def test_nested_contexts_are_added_to_exception_notes():
     ]
 
 
+def test_failing_add_note_does_not_mask_exception():
+    """A custom exception cannot replace itself while context is attached."""
+
+    class FailingAddNoteError(RuntimeError):
+        def add_note(self, _note):
+            raise RuntimeError("cannot add note")
+
+    original_error = FailingAddNoteError("original error")
+    with (
+        pytest.raises(FailingAddNoteError, match="original error") as caught,
+        warning_error_context("datapoint", {"item": 3}),
+    ):
+        raise original_error
+
+    assert caught.value is original_error
+    assert caught.value.__notes__ == ["Context: datapoint: item=3"]
+
+
 def test_iter_with_warning_error_context_scopes_nested_loop_bodies():
     """Iterator contexts nest explicitly and do not leak after a loop body."""
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -131,6 +131,33 @@ def test_context_records_warnings_and_errors_with_their_final_context():
     assert item_context.records == expected_records
 
 
+def test_context_can_be_started_and_stopped_without_with():
+    """A context can be activated manually without indenting the guarded code."""
+    original_warning = UserWarning("signal is short")
+    output = io.StringIO()
+    context = warning_error_context("script", {"phase": "processing"})
+
+    assert context.start() is context
+    with warnings.catch_warnings(record=True) as emitted_warnings:
+        warnings.simplefilter("always")
+        warnings.warn(original_warning, stacklevel=1)
+        print_with_context("processed", file=output)
+    context.stop()
+
+    with warnings.catch_warnings(record=True) as warnings_after_stop:
+        warnings.simplefilter("always")
+        warnings.warn("outside context", UserWarning, stacklevel=1)
+
+    expected_context = "script: phase='processing'"
+    assert str(emitted_warnings[0].message) == f"signal is short\n[{expected_context}] signal is short"
+    assert output.getvalue() == f"[{expected_context}] processed\n"
+    assert context.records == [
+        WarningErrorContextRecord("warning", expected_context, original_warning),
+        WarningErrorContextRecord("print", expected_context, "processed"),
+    ]
+    assert str(warnings_after_stop[0].message) == "outside context"
+
+
 def test_print_with_context_prints_and_records_like_print():
     """Contextual prints retain normal value, separator, terminator, and file handling."""
     output = io.StringIO()

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -8,6 +8,12 @@ import pytest
 from tpcp.misc import warning_error_context
 
 
+class _CustomWarning(UserWarning):
+    def __init__(self, message, detail):
+        super().__init__(message)
+        self.detail = detail
+
+
 def _emit_warning():
     warnings.warn("low level warning", UserWarning, stacklevel=1)
 
@@ -74,3 +80,17 @@ def test_sibling_contexts_do_not_leak_into_each_other():
             _emit_warning()
 
     assert "first" not in str(warning[0].message)
+
+
+def test_warning_instances_keep_their_type_and_data():
+    """Context metadata does not replace warning instances with plain strings."""
+    with (
+        warning_error_context("datapoint", group="patient-1"),
+        pytest.warns(
+            _CustomWarning,
+            match=re.escape("[datapoint: group='patient-1'] custom warning"),
+        ) as warning,
+    ):
+        warnings.warn(_CustomWarning("custom warning", detail="kept"), stacklevel=1)
+
+    assert warning[0].message.detail == "kept"

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -50,3 +50,27 @@ def test_context_is_cleaned_up_after_exception():
         _emit_warning()
 
     assert str(warning[0].message) == "low level warning"
+
+
+def test_sibling_contexts_do_not_leak_into_each_other():
+    """Sibling contexts under the same parent are pushed and popped independently."""
+    with warning_error_context("parent", item="recording-1"):
+        with (
+            warning_error_context("child", item="first"),
+            pytest.warns(
+                UserWarning,
+                match=re.escape("[parent: item='recording-1' > child: item='first'] low level warning"),
+            ),
+        ):
+            _emit_warning()
+
+        with (
+            warning_error_context("child", item="second"),
+            pytest.warns(
+                UserWarning,
+                match=re.escape("[parent: item='recording-1' > child: item='second'] low level warning"),
+            ) as warning,
+        ):
+            _emit_warning()
+
+    assert "first" not in str(warning[0].message)

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -74,6 +74,81 @@ def test_nested_contexts_are_added_to_exception_notes():
     ]
 
 
+def test_metadata_provider_is_resolved_for_each_warning():
+    """Dynamic metadata reflects state at the time each warning is rendered."""
+    state = {"step": 1}
+
+    with (
+        warning_error_context(
+            "iteration",
+            fixed="value",
+            metadata_provider=lambda: {"step": state["step"]},
+        ),
+        warnings.catch_warnings(record=True) as caught,
+    ):
+        warnings.simplefilter("always")
+        warnings.warn("first", UserWarning, stacklevel=1)
+        state["step"] = 2
+        warnings.warn("second", UserWarning, stacklevel=1)
+
+    assert [str(warning.message) for warning in caught] == [
+        "[iteration: fixed='value', step=1] first",
+        "[iteration: fixed='value', step=2] second",
+    ]
+
+
+def test_metadata_provider_is_resolved_when_exception_leaves_context():
+    """Exception notes contain dynamic metadata from the point of failure."""
+    state = {"step": 1}
+
+    def fail_after_state_change():
+        state["step"] = 2
+        raise ValueError("failed")
+
+    with (
+        pytest.raises(ValueError, match="failed") as error,
+        warning_error_context("iteration", metadata_provider=lambda: {"step": state["step"]}),
+    ):
+        fail_after_state_change()
+
+    assert error.value.__notes__ == ["Context: iteration: step=2"]
+
+
+@pytest.mark.parametrize(
+    ("metadata_provider", "error_text"),
+    [
+        (lambda: 1, "TypeError: metadata_provider must return a mapping"),
+        (lambda: {"fixed": "dynamic"}, "ValueError: metadata_provider returned duplicate keys: fixed"),
+        (lambda: 1 / 0, "ZeroDivisionError: division by zero"),
+    ],
+    ids=["not-a-mapping", "duplicate-key", "provider-raises"],
+)
+def test_metadata_provider_failure_does_not_mask_warning(metadata_provider, error_text):
+    """Invalid dynamic metadata is reported without replacing the warning."""
+    with (
+        warning_error_context("iteration", fixed="value", metadata_provider=metadata_provider),
+        pytest.warns(UserWarning, match="original warning") as caught,
+    ):
+        warnings.warn("original warning", UserWarning, stacklevel=1)
+
+    assert str(caught[0].message) == (
+        f"[iteration: fixed='value', metadata_provider_error={error_text!r}] original warning"
+    )
+
+
+def test_metadata_provider_failure_does_not_mask_exception():
+    """A provider failure is diagnostic context on the original exception."""
+    with (
+        pytest.raises(RuntimeError, match="original error") as error,
+        warning_error_context("iteration", metadata_provider=lambda: 1 / 0),
+    ):
+        raise RuntimeError("original error")
+
+    assert error.value.__notes__ == [
+        "Context: iteration: metadata_provider_error='ZeroDivisionError: division by zero'"
+    ]
+
+
 def test_context_is_cleaned_up_after_exception():
     """Contexts do not leak after an exception leaves the context manager."""
     with pytest.raises(ValueError, match="failed"), warning_error_context("datapoint", group="patient-1"):

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -1,18 +1,38 @@
 """Tests for warning and exception context metadata."""
 
+import _warnings
 import inspect
 import re
+import subprocess
+import sys
 import warnings
+from textwrap import dedent
 
 import pytest
+from joblib.externals import cloudpickle
 
-from tpcp.misc import warning_error_context
+_warn_alias_imported_before_tpcp = warnings.warn
+
+from tpcp.misc import warning_error_context  # noqa: E402  (import must happen after capturing warnings.warn)
 
 
 class _CustomWarning(UserWarning):
     def __init__(self, message, detail):
         super().__init__(message)
         self.detail = detail
+
+
+class _RequiredNewSlotWarning(UserWarning):
+    __slots__ = ("detail",)
+
+    def __new__(cls, message, detail):
+        instance = super().__new__(cls, message)
+        instance.detail = detail
+        return instance
+
+    def __init__(self, message, detail):
+        super().__init__(message)
+        self.payload = {"detail": detail}
 
 
 def _emit_warning():
@@ -101,6 +121,170 @@ def test_warning_instances_keep_their_type_and_data():
         warnings.warn(_CustomWarning("custom warning", detail="kept"), stacklevel=1)
 
     assert warning[0].message.detail == "kept"
+
+
+def test_warning_instances_with_required_new_arguments_and_slots_keep_their_type_and_data():
+    """Cloning a warning does not invoke its potentially custom constructor."""
+    original_warning = _RequiredNewSlotWarning("custom warning", detail="kept")
+
+    with (
+        warning_error_context("datapoint", group="patient-1"),
+        pytest.warns(
+            _RequiredNewSlotWarning,
+            match=re.escape("[datapoint: group='patient-1'] custom warning"),
+        ) as warning,
+    ):
+        warnings.warn(original_warning, stacklevel=1)
+
+    assert len(warning) == 1
+    assert warning[0].category is _RequiredNewSlotWarning
+    assert type(warning[0].message) is _RequiredNewSlotWarning
+    assert warning[0].message.detail == "kept"
+    assert warning[0].message.payload == {"detail": "kept"}
+    assert str(original_warning) == "custom warning"
+
+
+@pytest.mark.parametrize(
+    "emit_warning",
+    [
+        lambda: _warn_alias_imported_before_tpcp("aliased warning", UserWarning, stacklevel=1),
+        lambda: warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123),
+        lambda: _warnings.warn("C warning", UserWarning, stacklevel=1),
+    ],
+    ids=["pre-imported-warn-alias", "warn-explicit", "C-warnings-api"],
+)
+def test_context_is_added_for_all_warning_emitters(emit_warning):
+    """The dispatcher sees warning sources that do not call the current warnings.warn binding."""
+    with warning_error_context("datapoint", item=3), warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        emit_warning()
+
+    assert len(caught) == 1
+    assert str(caught[0].message).startswith("[datapoint: item=3] ")
+    assert caught[0].category is UserWarning
+
+
+def test_warn_explicit_location_is_preserved():
+    """Contextualizing an explicit warning keeps its synthetic location."""
+    with warning_error_context("datapoint", item=3), warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123)
+
+    assert len(caught) == 1
+    assert caught[0].filename == "synthetic_warning_source.py"
+    assert caught[0].lineno == 123
+
+
+def test_warning_message_is_forwarded_exactly_once(monkeypatch):
+    """The dispatcher forwards instead of re-emitting the warning."""
+    forwarded_messages = []
+    monkeypatch.setattr(warnings, "_showwarnmsg_impl", forwarded_messages.append)
+
+    with warning_error_context("datapoint", item=3):
+        warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123)
+
+    assert len(forwarded_messages) == 1
+    assert str(forwarded_messages[0].message) == "[datapoint: item=3] explicit warning"
+    assert forwarded_messages[0].filename == "synthetic_warning_source.py"
+    assert forwarded_messages[0].lineno == 123
+
+
+def test_warning_hook_installation_is_reload_safe():
+    """Reloading the module does not recurse or leave an inconsistent hook."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            dedent(
+                """
+                import importlib
+                import warnings
+
+                module = importlib.import_module("tpcp.misc._warning_error_context")
+                reloaded_module = importlib.reload(module)
+                with (
+                    reloaded_module.warning_error_context("reload", attempt=1),
+                    warnings.catch_warnings(record=True) as caught,
+                ):
+                    warnings.simplefilter("always")
+                    warnings.warn("reloaded warning", UserWarning, stacklevel=1)
+
+                assert len(caught) == 1
+                assert str(caught[0].message) == "[reload: attempt=1] reloaded warning"
+                assert warnings._showwarnmsg is reloaded_module._showwarnmsg_with_context
+                """
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_warning_hook_chains_to_preexisting_dispatcher_on_reload():
+    """Installation preserves a dispatcher that was not installed by tpcp."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            dedent(
+                """
+                import importlib
+                import warnings
+
+                module = importlib.import_module("tpcp.misc._warning_error_context")
+                hook_before_reload = warnings._showwarnmsg
+                original_attribute = module._TPCP_ORIGINAL_DISPATCHER
+                downstream_dispatcher = getattr(hook_before_reload, original_attribute, hook_before_reload)
+                third_party_messages = []
+
+                def third_party_dispatcher(message):
+                    third_party_messages.append(message)
+                    downstream_dispatcher(message)
+
+                warnings._showwarnmsg = third_party_dispatcher
+                reloaded_module = importlib.reload(module)
+                with (
+                    reloaded_module.warning_error_context("third-party"),
+                    warnings.catch_warnings(record=True) as caught,
+                ):
+                    warnings.simplefilter("always")
+                    warnings.warn("chained warning", UserWarning, stacklevel=1)
+
+                assert len(third_party_messages) == 1
+                assert str(third_party_messages[0].message) == "[third-party] chained warning"
+                assert len(caught) == 1
+                """
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_warning_dispatcher_is_cloudpickleable():
+    """The global hook remains import-addressable for multiprocessing workers."""
+    dispatcher = warnings._showwarnmsg
+
+    restored_dispatcher = cloudpickle.loads(cloudpickle.dumps(dispatcher))
+
+    assert restored_dispatcher is dispatcher
+
+
+def test_warning_location_is_preserved_with_context():
+    """Adding context does not change a stacklevel-derived warning location."""
+    with warning_error_context("datapoint", item=3), pytest.warns(UserWarning, match="location warning") as warning:
+        lineno = _emit_warning_with_line()
+
+    assert warning[0].filename == __file__
+    assert warning[0].lineno == lineno
 
 
 def test_warning_location_is_preserved_without_context():

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -14,6 +14,7 @@ from joblib.externals import cloudpickle
 _warn_alias_imported_before_tpcp = warnings.warn
 
 from tpcp.misc import (  # noqa: E402  (import must happen after capturing warnings.warn)
+    WarningErrorContextRecord,
     iter_with_warning_error_context,
     warning_error_context,
 )
@@ -89,6 +90,43 @@ def test_nested_contexts_are_added_to_exception_notes():
         "Context: region: start=10, end=20",
         "Context: datapoint: group='patient-1'",
     ]
+
+
+def test_context_records_warnings_and_errors_with_their_final_context():
+    """Active contexts retain original diagnostics with the fully resolved stack."""
+    original_warning = UserWarning("signal is short")
+    original_error = ValueError("invalid signal")
+    state = {"step": 1}
+
+    try:
+        with (
+            warning_error_context("dataset", {"name": "validation"}) as dataset_context,
+            warning_error_context("item", context_provider=lambda: {"step": state["step"]}) as item_context,
+            warnings.catch_warnings(record=True),
+        ):
+            warnings.simplefilter("always")
+            warnings.warn(original_warning, stacklevel=1)
+            state["step"] = 2
+            raise original_error
+    except ValueError:
+        pass
+    else:
+        pytest.fail("The original error was not re-raised.")
+
+    expected_records = [
+        WarningErrorContextRecord(
+            "warning",
+            "dataset: name='validation' > item: step=1",
+            original_warning,
+        ),
+        WarningErrorContextRecord(
+            "error",
+            "dataset: name='validation' > item: step=2",
+            original_error,
+        ),
+    ]
+    assert dataset_context.records == expected_records
+    assert item_context.records == expected_records
 
 
 def test_failing_add_note_does_not_mask_exception():

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -106,13 +106,13 @@ def test_iter_with_warning_error_context_injects_a_stable_iteration_index():
             with make_context("item", {"value": item}):
                 warnings.warn("item warning", UserWarning, stacklevel=1)
 
-        with factories[0]("saved", {}):
+        with factories[0]("saved", context_provider=lambda: {"dynamic": True}):
             warnings.warn("saved warning", UserWarning, stacklevel=1)
 
     assert [str(warning.message) for warning in caught] == [
         "[item: i=0, value='first'] item warning",
         "[item: i=1, value='second'] item warning",
-        "[saved: i=0] saved warning",
+        "[saved: i=0, dynamic=True] saved warning",
     ]
 
 
@@ -148,6 +148,17 @@ def test_context_provider_is_resolved_for_each_warning():
         "[iteration: fixed='value', step=1] first",
         "[iteration: fixed='value', step=2] second",
     ]
+
+
+def test_context_provider_can_be_used_without_fixed_context():
+    """A dynamic provider does not require an empty context dictionary."""
+    with (
+        warning_error_context("iteration", context_provider=lambda: {"step": 1}),
+        pytest.warns(UserWarning) as caught,
+    ):
+        warnings.warn("provider-only warning", UserWarning, stacklevel=1)
+
+    assert str(caught[0].message) == "[iteration: step=1] provider-only warning"
 
 
 def test_context_provider_is_resolved_when_exception_leaves_context():

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -1,0 +1,52 @@
+"""Tests for warning and exception context metadata."""
+
+import re
+import warnings
+
+import pytest
+
+from tpcp.misc import warning_error_context
+
+
+def _emit_warning():
+    warnings.warn("low level warning", UserWarning, stacklevel=1)
+
+
+def test_nested_contexts_are_added_to_warnings():
+    """Nested contexts are rendered in emitted warning messages."""
+    with (
+        warning_error_context("datapoint", group="patient-1"),
+        warning_error_context("region", start=10, end=20),
+        pytest.warns(
+            UserWarning,
+            match=re.escape("[datapoint: group='patient-1' > region: start=10, end=20] low level warning"),
+        ),
+    ):
+        _emit_warning()
+
+
+def test_nested_contexts_are_added_to_exception_notes():
+    """Nested contexts are attached as exception notes without changing the exception."""
+    with (
+        pytest.raises(ValueError, match="failed") as error,
+        warning_error_context("datapoint", group="patient-1"),
+        warning_error_context("region", start=10, end=20),
+    ):
+        raise ValueError("failed")
+
+    assert error.value.args == ("failed",)
+    assert error.value.__notes__ == [
+        "Context: region: start=10, end=20",
+        "Context: datapoint: group='patient-1'",
+    ]
+
+
+def test_context_is_cleaned_up_after_exception():
+    """Contexts do not leak after an exception leaves the context manager."""
+    with pytest.raises(ValueError, match="failed"), warning_error_context("datapoint", group="patient-1"):
+        raise ValueError("failed")
+
+    with pytest.warns(UserWarning, match="low level warning") as warning:
+        _emit_warning()
+
+    assert str(warning[0].message) == "low level warning"

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -1,5 +1,6 @@
 """Tests for warning and exception context metadata."""
 
+import inspect
 import re
 import warnings
 
@@ -16,6 +17,12 @@ class _CustomWarning(UserWarning):
 
 def _emit_warning():
     warnings.warn("low level warning", UserWarning, stacklevel=1)
+
+
+def _emit_warning_with_line():
+    lineno = inspect.currentframe().f_lineno + 1
+    warnings.warn("location warning", UserWarning, stacklevel=1)
+    return lineno
 
 
 def test_nested_contexts_are_added_to_warnings():
@@ -94,3 +101,12 @@ def test_warning_instances_keep_their_type_and_data():
         warnings.warn(_CustomWarning("custom warning", detail="kept"), stacklevel=1)
 
     assert warning[0].message.detail == "kept"
+
+
+def test_warning_location_is_preserved_without_context():
+    """The global warning wrapper does not change locations for unrelated warnings."""
+    with pytest.warns(UserWarning, match="location warning") as warning:
+        lineno = _emit_warning_with_line()
+
+    assert warning[0].filename == __file__
+    assert warning[0].lineno == lineno

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -51,8 +51,8 @@ def _emit_warning_with_line():
 def test_nested_contexts_are_added_to_warnings():
     """Nested contexts are rendered in emitted warning messages."""
     with (
-        warning_error_context("datapoint", group="patient-1"),
-        warning_error_context("region", start=10, end=20),
+        warning_error_context("datapoint", {"group": "patient-1"}),
+        warning_error_context("region", {"start": 10, "end": 20}),
         pytest.warns(
             UserWarning,
             match=re.escape("[datapoint: group='patient-1' > region: start=10, end=20] low level warning"),
@@ -65,8 +65,8 @@ def test_nested_contexts_are_added_to_exception_notes():
     """Nested contexts are attached as exception notes without changing the exception."""
     with (
         pytest.raises(ValueError, match="failed") as error,
-        warning_error_context("datapoint", group="patient-1"),
-        warning_error_context("region", start=10, end=20),
+        warning_error_context("datapoint", {"group": "patient-1"}),
+        warning_error_context("region", {"start": 10, "end": 20}),
     ):
         raise ValueError("failed")
 
@@ -82,29 +82,60 @@ def test_iter_with_warning_error_context_scopes_nested_loop_bodies():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         for make_outer_context, outer_item in iter_with_warning_error_context([1]):
-            with make_outer_context("outer", item=outer_item):
+            with make_outer_context("outer", {"item": outer_item}):
                 for make_inner_context, inner_item in iter_with_warning_error_context([2]):
-                    with make_inner_context("inner", item=inner_item):
+                    with make_inner_context("inner", {"item": inner_item}):
                         warnings.warn("inner warning", UserWarning, stacklevel=1)
                 warnings.warn("outer warning", UserWarning, stacklevel=1)
         warnings.warn("unscoped warning", UserWarning, stacklevel=1)
 
     assert [str(warning.message) for warning in caught] == [
-        "[outer: item=1 > inner: item=2] inner warning",
-        "[outer: item=1] outer warning",
+        "[outer: i=0, item=1 > inner: i=0, item=2] inner warning",
+        "[outer: i=0, item=1] outer warning",
         "unscoped warning",
     ]
 
 
-def test_metadata_provider_is_resolved_for_each_warning():
+def test_iter_with_warning_error_context_injects_a_stable_iteration_index():
+    """Every yielded creator retains its own zero-based index."""
+    factories = []
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for make_context, item in iter_with_warning_error_context(["first", "second"]):
+            factories.append(make_context)
+            with make_context("item", {"value": item}):
+                warnings.warn("item warning", UserWarning, stacklevel=1)
+
+        with factories[0]("saved", {}):
+            warnings.warn("saved warning", UserWarning, stacklevel=1)
+
+    assert [str(warning.message) for warning in caught] == [
+        "[item: i=0, value='first'] item warning",
+        "[item: i=1, value='second'] item warning",
+        "[saved: i=0] saved warning",
+    ]
+
+
+def test_warning_error_context_copies_the_explicit_context_dict():
+    """Mutating the input dictionary does not change an active fixed context."""
+    context = {"value": "initial"}
+    with warning_error_context("copy", context), warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        context["value"] = "changed"
+        warnings.warn("copied warning", UserWarning, stacklevel=1)
+
+    assert str(caught[0].message) == "[copy: value='initial'] copied warning"
+
+
+def test_context_provider_is_resolved_for_each_warning():
     """Dynamic metadata reflects state at the time each warning is rendered."""
     state = {"step": 1}
 
     with (
         warning_error_context(
             "iteration",
-            fixed="value",
-            metadata_provider=lambda: {"step": state["step"]},
+            {"fixed": "value"},
+            context_provider=lambda: {"step": state["step"]},
         ),
         warnings.catch_warnings(record=True) as caught,
     ):
@@ -119,7 +150,7 @@ def test_metadata_provider_is_resolved_for_each_warning():
     ]
 
 
-def test_metadata_provider_is_resolved_when_exception_leaves_context():
+def test_context_provider_is_resolved_when_exception_leaves_context():
     """Exception notes contain dynamic metadata from the point of failure."""
     state = {"step": 1}
 
@@ -129,7 +160,7 @@ def test_metadata_provider_is_resolved_when_exception_leaves_context():
 
     with (
         pytest.raises(ValueError, match="failed") as error,
-        warning_error_context("iteration", metadata_provider=lambda: {"step": state["step"]}),
+        warning_error_context("iteration", {}, context_provider=lambda: {"step": state["step"]}),
     ):
         fail_after_state_change()
 
@@ -137,43 +168,78 @@ def test_metadata_provider_is_resolved_when_exception_leaves_context():
 
 
 @pytest.mark.parametrize(
-    ("metadata_provider", "error_text"),
+    ("context_provider", "error_text"),
     [
-        (lambda: 1, "TypeError: metadata_provider must return a mapping"),
-        (lambda: {"fixed": "dynamic"}, "ValueError: metadata_provider returned duplicate keys: fixed"),
+        (lambda: 1, "TypeError: context_provider must return a mapping"),
+        (lambda: {"fixed": "dynamic"}, "ValueError: context_provider returned duplicate keys: fixed"),
         (lambda: 1 / 0, "ZeroDivisionError: division by zero"),
     ],
     ids=["not-a-mapping", "duplicate-key", "provider-raises"],
 )
-def test_metadata_provider_failure_does_not_mask_warning(metadata_provider, error_text):
+def test_context_provider_failure_does_not_mask_warning(context_provider, error_text):
     """Invalid dynamic metadata is reported without replacing the warning."""
     with (
-        warning_error_context("iteration", fixed="value", metadata_provider=metadata_provider),
+        warning_error_context("iteration", {"fixed": "value"}, context_provider=context_provider),
         pytest.warns(UserWarning, match="original warning") as caught,
     ):
         warnings.warn("original warning", UserWarning, stacklevel=1)
 
     assert str(caught[0].message) == (
-        f"[iteration: fixed='value', metadata_provider_error={error_text!r}] original warning"
+        f"[iteration: fixed='value', context_provider_error={error_text!r}] original warning"
     )
 
 
-def test_metadata_provider_failure_does_not_mask_exception():
+def test_context_provider_failure_does_not_mask_exception():
     """A provider failure is diagnostic context on the original exception."""
     with (
         pytest.raises(RuntimeError, match="original error") as error,
-        warning_error_context("iteration", metadata_provider=lambda: 1 / 0),
+        warning_error_context("iteration", {}, context_provider=lambda: 1 / 0),
     ):
         raise RuntimeError("original error")
 
-    assert error.value.__notes__ == [
-        "Context: iteration: metadata_provider_error='ZeroDivisionError: division by zero'"
-    ]
+    assert error.value.__notes__ == ["Context: iteration: context_provider_error='ZeroDivisionError: division by zero'"]
+
+
+def test_context_value_repr_failure_does_not_mask_warning():
+    """An unrenderable context value does not replace the original warning."""
+
+    class BrokenRepr:
+        def __repr__(self):
+            raise RuntimeError("repr failed")
+
+    with (
+        warning_error_context("iteration", {"value": BrokenRepr()}),
+        pytest.warns(UserWarning, match="original warning") as caught,
+    ):
+        warnings.warn("original warning", UserWarning, stacklevel=1)
+
+    assert str(caught[0].message) == "[iteration: value=<repr failed: RuntimeError>] original warning"
+
+
+def test_context_provider_error_str_failure_does_not_mask_warning():
+    """An unrenderable provider error does not replace the original warning."""
+
+    class BrokenStrError(RuntimeError):
+        def __str__(self):
+            raise RuntimeError("str failed")
+
+    def broken_provider():
+        raise BrokenStrError
+
+    with (
+        warning_error_context("iteration", context_provider=broken_provider),
+        pytest.warns(UserWarning, match="original warning") as caught,
+    ):
+        warnings.warn("original warning", UserWarning, stacklevel=1)
+
+    assert str(caught[0].message) == (
+        "[iteration: context_provider_error='BrokenStrError: <str failed: RuntimeError>'] original warning"
+    )
 
 
 def test_context_is_cleaned_up_after_exception():
     """Contexts do not leak after an exception leaves the context manager."""
-    with pytest.raises(ValueError, match="failed"), warning_error_context("datapoint", group="patient-1"):
+    with pytest.raises(ValueError, match="failed"), warning_error_context("datapoint", {"group": "patient-1"}):
         raise ValueError("failed")
 
     with pytest.warns(UserWarning, match="low level warning") as warning:
@@ -184,9 +250,9 @@ def test_context_is_cleaned_up_after_exception():
 
 def test_sibling_contexts_do_not_leak_into_each_other():
     """Sibling contexts under the same parent are pushed and popped independently."""
-    with warning_error_context("parent", item="recording-1"):
+    with warning_error_context("parent", {"item": "recording-1"}):
         with (
-            warning_error_context("child", item="first"),
+            warning_error_context("child", {"item": "first"}),
             pytest.warns(
                 UserWarning,
                 match=re.escape("[parent: item='recording-1' > child: item='first'] low level warning"),
@@ -195,7 +261,7 @@ def test_sibling_contexts_do_not_leak_into_each_other():
             _emit_warning()
 
         with (
-            warning_error_context("child", item="second"),
+            warning_error_context("child", {"item": "second"}),
             pytest.warns(
                 UserWarning,
                 match=re.escape("[parent: item='recording-1' > child: item='second'] low level warning"),
@@ -209,7 +275,7 @@ def test_sibling_contexts_do_not_leak_into_each_other():
 def test_warning_instances_keep_their_type_and_data():
     """Context metadata does not replace warning instances with plain strings."""
     with (
-        warning_error_context("datapoint", group="patient-1"),
+        warning_error_context("datapoint", {"group": "patient-1"}),
         pytest.warns(
             _CustomWarning,
             match=re.escape("[datapoint: group='patient-1'] custom warning"),
@@ -225,7 +291,7 @@ def test_warning_instances_with_required_new_arguments_and_slots_keep_their_type
     original_warning = _RequiredNewSlotWarning("custom warning", detail="kept")
 
     with (
-        warning_error_context("datapoint", group="patient-1"),
+        warning_error_context("datapoint", {"group": "patient-1"}),
         pytest.warns(
             _RequiredNewSlotWarning,
             match=re.escape("[datapoint: group='patient-1'] custom warning"),
@@ -252,7 +318,7 @@ def test_warning_instances_with_required_new_arguments_and_slots_keep_their_type
 )
 def test_context_is_added_for_all_warning_emitters(emit_warning):
     """The dispatcher sees warning sources that do not call the current warnings.warn binding."""
-    with warning_error_context("datapoint", item=3), warnings.catch_warnings(record=True) as caught:
+    with warning_error_context("datapoint", {"item": 3}), warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         emit_warning()
 
@@ -263,7 +329,7 @@ def test_context_is_added_for_all_warning_emitters(emit_warning):
 
 def test_warn_explicit_location_is_preserved():
     """Contextualizing an explicit warning keeps its synthetic location."""
-    with warning_error_context("datapoint", item=3), warnings.catch_warnings(record=True) as caught:
+    with warning_error_context("datapoint", {"item": 3}), warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123)
 
@@ -277,7 +343,7 @@ def test_warning_message_is_forwarded_exactly_once(monkeypatch):
     forwarded_messages = []
     monkeypatch.setattr(warnings, "_showwarnmsg_impl", forwarded_messages.append)
 
-    with warning_error_context("datapoint", item=3):
+    with warning_error_context("datapoint", {"item": 3}):
         warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123)
 
     assert len(forwarded_messages) == 1
@@ -300,7 +366,7 @@ def test_warning_hook_installation_is_reload_safe():
                 module = importlib.import_module("tpcp.misc._warning_error_context")
                 reloaded_module = importlib.reload(module)
                 with (
-                    reloaded_module.warning_error_context("reload", attempt=1),
+                    reloaded_module.warning_error_context("reload", {"attempt": 1}),
                     warnings.catch_warnings(record=True) as caught,
                 ):
                     warnings.simplefilter("always")
@@ -345,7 +411,7 @@ def test_warning_hook_chains_to_preexisting_dispatcher_on_reload():
                 warnings._showwarnmsg = third_party_dispatcher
                 reloaded_module = importlib.reload(module)
                 with (
-                    reloaded_module.warning_error_context("third-party"),
+                    reloaded_module.warning_error_context("third-party", {}),
                     warnings.catch_warnings(record=True) as caught,
                 ):
                     warnings.simplefilter("always")
@@ -377,7 +443,10 @@ def test_warning_dispatcher_is_cloudpickleable():
 
 def test_warning_location_is_preserved_with_context():
     """Adding context does not change a stacklevel-derived warning location."""
-    with warning_error_context("datapoint", item=3), pytest.warns(UserWarning, match="location warning") as warning:
+    with (
+        warning_error_context("datapoint", {"item": 3}),
+        pytest.warns(UserWarning, match="location warning") as warning,
+    ):
         lineno = _emit_warning_with_line()
 
     assert warning[0].filename == __file__

--- a/tests/test_misc/test_warning_error_context.py
+++ b/tests/test_misc/test_warning_error_context.py
@@ -61,6 +61,20 @@ def test_nested_contexts_are_added_to_warnings():
         _emit_warning()
 
 
+def test_formatted_warning_starts_context_on_a_new_line():
+    """Context is visually separated from the warning location and category."""
+    with warning_error_context("datapoint", {"item": 3}), warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.warn("low level warning", UserWarning, stacklevel=1)
+
+    filename = "/a/deliberately/long/path/to/the/module/emitting/the/warning.py"
+    formatted_warning = warnings.formatwarning(caught[0].message, caught[0].category, filename, 123)
+
+    assert formatted_warning == (
+        f"{filename}:123: UserWarning: low level warning\n[datapoint: item=3] low level warning\n"
+    )
+
+
 def test_nested_contexts_are_added_to_exception_notes():
     """Nested contexts are attached as exception notes without changing the exception."""
     with (
@@ -90,8 +104,8 @@ def test_iter_with_warning_error_context_scopes_nested_loop_bodies():
         warnings.warn("unscoped warning", UserWarning, stacklevel=1)
 
     assert [str(warning.message) for warning in caught] == [
-        "[outer: i=0, item=1 > inner: i=0, item=2] inner warning",
-        "[outer: i=0, item=1] outer warning",
+        "inner warning\n[outer: i=0, item=1 > inner: i=0, item=2] inner warning",
+        "outer warning\n[outer: i=0, item=1] outer warning",
         "unscoped warning",
     ]
 
@@ -110,9 +124,9 @@ def test_iter_with_warning_error_context_injects_a_stable_iteration_index():
             warnings.warn("saved warning", UserWarning, stacklevel=1)
 
     assert [str(warning.message) for warning in caught] == [
-        "[item: i=0, value='first'] item warning",
-        "[item: i=1, value='second'] item warning",
-        "[saved: i=0, dynamic=True] saved warning",
+        "item warning\n[item: i=0, value='first'] item warning",
+        "item warning\n[item: i=1, value='second'] item warning",
+        "saved warning\n[saved: i=0, dynamic=True] saved warning",
     ]
 
 
@@ -124,7 +138,7 @@ def test_warning_error_context_copies_the_explicit_context_dict():
         context["value"] = "changed"
         warnings.warn("copied warning", UserWarning, stacklevel=1)
 
-    assert str(caught[0].message) == "[copy: value='initial'] copied warning"
+    assert str(caught[0].message) == "copied warning\n[copy: value='initial'] copied warning"
 
 
 def test_context_provider_is_resolved_for_each_warning():
@@ -145,8 +159,8 @@ def test_context_provider_is_resolved_for_each_warning():
         warnings.warn("second", UserWarning, stacklevel=1)
 
     assert [str(warning.message) for warning in caught] == [
-        "[iteration: fixed='value', step=1] first",
-        "[iteration: fixed='value', step=2] second",
+        "first\n[iteration: fixed='value', step=1] first",
+        "second\n[iteration: fixed='value', step=2] second",
     ]
 
 
@@ -158,7 +172,7 @@ def test_context_provider_can_be_used_without_fixed_context():
     ):
         warnings.warn("provider-only warning", UserWarning, stacklevel=1)
 
-    assert str(caught[0].message) == "[iteration: step=1] provider-only warning"
+    assert str(caught[0].message) == "provider-only warning\n[iteration: step=1] provider-only warning"
 
 
 def test_context_provider_is_resolved_when_exception_leaves_context():
@@ -196,7 +210,7 @@ def test_context_provider_failure_does_not_mask_warning(context_provider, error_
         warnings.warn("original warning", UserWarning, stacklevel=1)
 
     assert str(caught[0].message) == (
-        f"[iteration: fixed='value', context_provider_error={error_text!r}] original warning"
+        f"original warning\n[iteration: fixed='value', context_provider_error={error_text!r}] original warning"
     )
 
 
@@ -224,7 +238,9 @@ def test_context_value_repr_failure_does_not_mask_warning():
     ):
         warnings.warn("original warning", UserWarning, stacklevel=1)
 
-    assert str(caught[0].message) == "[iteration: value=<repr failed: RuntimeError>] original warning"
+    assert str(caught[0].message) == (
+        "original warning\n[iteration: value=<repr failed: RuntimeError>] original warning"
+    )
 
 
 def test_context_provider_error_str_failure_does_not_mask_warning():
@@ -244,6 +260,7 @@ def test_context_provider_error_str_failure_does_not_mask_warning():
         warnings.warn("original warning", UserWarning, stacklevel=1)
 
     assert str(caught[0].message) == (
+        "original warning\n"
         "[iteration: context_provider_error='BrokenStrError: <str failed: RuntimeError>'] original warning"
     )
 
@@ -334,7 +351,7 @@ def test_context_is_added_for_all_warning_emitters(emit_warning):
         emit_warning()
 
     assert len(caught) == 1
-    assert str(caught[0].message).startswith("[datapoint: item=3] ")
+    assert "\n[datapoint: item=3] " in str(caught[0].message)
     assert caught[0].category is UserWarning
 
 
@@ -358,7 +375,7 @@ def test_warning_message_is_forwarded_exactly_once(monkeypatch):
         warnings.warn_explicit("explicit warning", UserWarning, "synthetic_warning_source.py", 123)
 
     assert len(forwarded_messages) == 1
-    assert str(forwarded_messages[0].message) == "[datapoint: item=3] explicit warning"
+    assert str(forwarded_messages[0].message) == "explicit warning\n[datapoint: item=3] explicit warning"
     assert forwarded_messages[0].filename == "synthetic_warning_source.py"
     assert forwarded_messages[0].lineno == 123
 
@@ -384,7 +401,7 @@ def test_warning_hook_installation_is_reload_safe():
                     warnings.warn("reloaded warning", UserWarning, stacklevel=1)
 
                 assert len(caught) == 1
-                assert str(caught[0].message) == "[reload: attempt=1] reloaded warning"
+                assert str(caught[0].message) == "reloaded warning\\n[reload: attempt=1] reloaded warning"
                 assert warnings._showwarnmsg is reloaded_module._showwarnmsg_with_context
                 """
             ),
@@ -429,7 +446,7 @@ def test_warning_hook_chains_to_preexisting_dispatcher_on_reload():
                     warnings.warn("chained warning", UserWarning, stacklevel=1)
 
                 assert len(third_party_messages) == 1
-                assert str(third_party_messages[0].message) == "[third-party] chained warning"
+                assert str(third_party_messages[0].message) == "chained warning\\n[third-party] chained warning"
                 assert len(caught) == 1
                 """
             ),

--- a/tests/test_pipelines/test_optimize.py
+++ b/tests/test_pipelines/test_optimize.py
@@ -355,10 +355,12 @@ class TestGridSearch:
             CustomErrorPipeline(error_para=error_para), ParameterGrid({"para": [1, 2]}), scoring=simple_scorer
         )
 
-        with pytest.raises(TestError) as e:
+        with pytest.raises(TestError, match="Testing failed") as e:
             gs.optimize(DummyDataset())
 
-        assert f"This error occurred for the following parameter:\n\n{{'para': {error_para}}}" in str(e.value)
+        assert e.value.__notes__ == [
+            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}"
+        ]
 
 
 class TestGridSearchCV:
@@ -705,10 +707,14 @@ class TestGridSearchCV:
             scoring=simple_scorer,
         )
 
-        with pytest.raises(OptimizationError) as e:
+        with pytest.raises(OptimizationError, match="Optimization failed") as e:
             gs.optimize(DummyDataset())
 
-        assert f"This error occurred in fold {error_fold} with parameters candidate {error_para - 1}." in str(e.value)
+        assert e.value.__notes__ == [
+            f"Context: cv_fold: index={error_fold}",
+            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}",
+        ]
+        assert e.value.__cause__.__notes__[0].startswith("Context: optimize:")
 
 
 class TestOptimize:

--- a/tests/test_pipelines/test_optimize.py
+++ b/tests/test_pipelines/test_optimize.py
@@ -358,6 +358,10 @@ class TestGridSearch:
         with pytest.raises(TestError, match="Testing failed") as e:
             gs.optimize(DummyDataset())
 
+        assert (
+            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}} > score:"
+            in str(e.value)
+        )
         assert e.value.__notes__ == [
             f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}"
         ]
@@ -710,6 +714,10 @@ class TestGridSearchCV:
         with pytest.raises(OptimizationError, match="Optimization failed") as e:
             gs.optimize(DummyDataset())
 
+        assert (
+            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}} "
+            f"> cv_fold: index={error_fold} > optimize:" in str(e.value)
+        )
         assert e.value.__notes__ == [
             f"Context: cv_fold: index={error_fold}",
             f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}",

--- a/tests/test_pipelines/test_optuna_optimize.py
+++ b/tests/test_pipelines/test_optuna_optimize.py
@@ -147,13 +147,14 @@ class TestCustomOptunaOptimize:
         assert isinstance(mock_objective.call_args[0][0], Trial)
 
     def test_objective_warning_contains_trial_context(self):
-        def objective(_trial, _pipeline, _dataset):
+        def objective(trial, _pipeline, _dataset):
+            trial.suggest_categorical("selected_param", ["selected_value"])
             warnings.warn("objective warning", UserWarning, stacklevel=1)
             return 3
 
         with pytest.warns(
             UserWarning,
-            match=re.escape("[optuna_trial: number=0, params={}] objective warning"),
+            match=re.escape("[optuna_trial: number=0, params={'selected_param': 'selected_value'}] objective warning"),
         ):
             DummyOptunaOptimizer(
                 DummyOptimizablePipeline(),

--- a/tests/test_pipelines/test_optuna_optimize.py
+++ b/tests/test_pipelines/test_optuna_optimize.py
@@ -1,4 +1,6 @@
+import re
 import tempfile
+import warnings
 from collections.abc import Sequence
 from typing import Callable, Optional, Union
 from unittest.mock import Mock, patch
@@ -143,6 +145,26 @@ class TestCustomOptunaOptimize:
         assert mock_objective.call_args[0][1] is not pipe
 
         assert isinstance(mock_objective.call_args[0][0], Trial)
+
+    def test_objective_warning_contains_trial_context(self):
+        def objective(_trial, _pipeline, _dataset):
+            warnings.warn("objective warning", UserWarning, stacklevel=1)
+            return 3
+
+        with pytest.warns(
+            UserWarning,
+            match=re.escape("[optuna_trial: number=0, params={}] objective warning"),
+        ):
+            DummyOptunaOptimizer(
+                DummyOptimizablePipeline(),
+                _get_study_params,
+                scoring=dummy_single_score_func,
+                create_search_space=dummy_search_space,
+                n_trials=1,
+                timeout=None,
+                mock_objective=objective,
+                return_optimized=False,
+            ).optimize(DummyDataset())
 
     @pytest.mark.parametrize("return_optimize", [True, False])
     def test_return_optimized(self, return_optimize):

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -176,7 +176,10 @@ class TestScorer:
         scorer = Scorer(score_func)
         pipe = DummyOptimizablePipeline()
         data = DummyDataset()
-        with pytest.raises(ScorerFailedError, match=re.escape("Scorer failed while scoring a datapoint.")) as e:
+        with pytest.raises(
+            ScorerFailedError,
+            match=re.escape("Scorer failed while scoring datapoint 0 (DummyDatasetGroupLabel(value=0))."),
+        ) as e:
             scorer(pipe, data)
 
         assert isinstance(e.value.__cause__, RuntimeError)

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -176,13 +176,83 @@ class TestScorer:
         scorer = Scorer(score_func)
         pipe = DummyOptimizablePipeline()
         data = DummyDataset()
-        with pytest.raises(ScorerFailedError, match=re.escape("Scorer failed while scoring a datapoint.")) as e:
+        with pytest.raises(
+            ScorerFailedError,
+            match=re.escape("Scorer failed while scoring datapoint 0 (DummyDatasetGroupLabel(value=0))."),
+        ) as e:
             scorer(pipe, data)
 
         assert isinstance(e.value.__cause__, RuntimeError)
         assert e.value.__cause__.__notes__ == [
             "Context: datapoint: index=0, group_label=DummyDatasetGroupLabel(value=0)"
         ]
+
+    def test_group_label_error_is_wrapped_without_reading_the_label_again(self):
+        """A failing context value cannot mask the scorer's public wrapper error."""
+
+        class BrokenGroupLabelDataset(DummyDataset):
+            @property
+            def group_label(self):
+                raise RuntimeError("group label failed")
+
+        scorer = Scorer(lambda _pipeline, _data_point: 1)
+
+        with pytest.raises(
+            ScorerFailedError, match=re.escape("Scorer failed while scoring datapoint 0 (<unavailable>).")
+        ) as error:
+            scorer(DummyOptimizablePipeline(), BrokenGroupLabelDataset()[0])
+
+        assert isinstance(error.value.__cause__, RuntimeError)
+        assert str(error.value.__cause__) == "group label failed"
+
+    def test_unrenderable_group_label_cannot_mask_a_scoring_error(self):
+        """Wrapper diagnostics tolerate labels whose string conversion fails."""
+
+        class BrokenRenderLabel:
+            def __str__(self):
+                raise RuntimeError("label str failed")
+
+            def __repr__(self):
+                raise RuntimeError("label repr failed")
+
+        class BrokenRenderLabelDataset(DummyDataset):
+            @property
+            def group_label(self):
+                return BrokenRenderLabel()
+
+        def score_func(_pipeline, _data_point):
+            raise RuntimeError("score failed")
+
+        with pytest.raises(
+            ScorerFailedError,
+            match=re.escape("Scorer failed while scoring datapoint 0 (<unrenderable BrokenRenderLabel>)."),
+        ) as error:
+            Scorer(score_func)(DummyOptimizablePipeline(), BrokenRenderLabelDataset()[0])
+
+        assert isinstance(error.value.__cause__, RuntimeError)
+        assert str(error.value.__cause__) == "score failed"
+
+    def test_group_label_is_not_rendered_during_successful_scoring(self):
+        """Successful datapoints do not invoke diagnostic label rendering."""
+        render_calls = []
+
+        class LabelThatMustNotBeRendered:
+            def __str__(self):
+                render_calls.append("str")
+                return "label"
+
+        class UnrenderedLabelDataset(DummyDataset):
+            @property
+            def group_label(self):
+                return LabelThatMustNotBeRendered()
+
+        aggregated, raw = Scorer(lambda _pipeline, _data_point: 1)(
+            DummyOptimizablePipeline(), UnrenderedLabelDataset()[0]
+        )
+
+        assert aggregated == 1
+        assert raw == [1]
+        assert render_calls == []
 
     def test_score_func_warning_contains_datapoint_context(self):
         """Score-function warnings include the active datapoint context."""

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -1,3 +1,5 @@
+import re
+import warnings
 from collections.abc import Sequence
 from itertools import cycle
 from unittest import mock
@@ -166,16 +168,37 @@ class TestScorer:
         assert "are: ('val1', 'val2')" in str(e)
 
     def test_score_func_raises_exception(self):
-        def score_func(x, y):
-            raise Exception("test")
+        """Score-function exceptions keep datapoint context on the original error."""
+
+        def score_func(_pipeline, _data_point):
+            raise RuntimeError("test")
 
         scorer = Scorer(score_func)
         pipe = DummyOptimizablePipeline()
         data = DummyDataset()
-        with pytest.raises(ScorerFailedError) as e:
+        with pytest.raises(ScorerFailedError, match=re.escape("Scorer failed while scoring a datapoint.")) as e:
             scorer(pipe, data)
 
-        assert 'Exception("test")' in str(e)
+        assert isinstance(e.value.__cause__, RuntimeError)
+        assert e.value.__cause__.__notes__ == [
+            "Context: datapoint: index=0, group_label=DummyDatasetGroupLabel(value=0)"
+        ]
+
+    def test_score_func_warning_contains_datapoint_context(self):
+        """Score-function warnings include the active datapoint context."""
+
+        def score_func(_pipeline, _data_point):
+            warnings.warn("scorer warning", UserWarning, stacklevel=1)
+            return 1
+
+        scorer = Scorer(score_func)
+        pipe = DummyOptimizablePipeline()
+
+        with pytest.warns(
+            UserWarning,
+            match=re.escape("[datapoint: index=0, group_label=DummyDatasetGroupLabel(value=0)] scorer warning"),
+        ):
+            scorer(pipe, DummyDataset()[0])
 
 
 def _dummy_func(x):

--- a/tests/test_pipelines/test_validate.py
+++ b/tests/test_pipelines/test_validate.py
@@ -241,7 +241,7 @@ class TestCrossValidate:
 
     @pytest.mark.parametrize("error_fold", [0, 2])
     def test_cross_validate_opti_error(self, error_fold):
-        with pytest.raises(OptimizationError) as e:
+        with pytest.raises(OptimizationError, match="Optimization failed") as e:
             cross_validate(
                 Optimize(CustomOptimizablePipelineWithOptiError(error_fold=error_fold)),
                 DummyDataset(),
@@ -249,7 +249,7 @@ class TestCrossValidate:
                 cv=5,
             )
 
-        assert f"This error occurred in fold {error_fold}" in str(e.value)
+        assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
 
     @pytest.mark.parametrize("error_fold", [0, 2])
     def test_cross_validate_test_error(self, error_fold):
@@ -257,7 +257,7 @@ class TestCrossValidate:
             pipeline.run(data_point)
             return data_point.group_labels[0]
 
-        with pytest.raises(TestError) as e:
+        with pytest.raises(TestError, match="Testing failed") as e:
             cross_validate(
                 DummyOptimize(CustomOptimizablePipelineWithRunError(error_fold=error_fold)),
                 DummyDataset(),
@@ -265,7 +265,11 @@ class TestCrossValidate:
                 cv=5,
             )
 
-        assert f"This error occurred in fold {error_fold}" in str(e.value)
+        assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
+        assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
+        assert e.value.__cause__.__cause__.__notes__ == [
+            f"Context: datapoint: index=0, group_label=DummyDatasetGroupLabel(value={error_fold})"
+        ]
 
     @pytest.mark.parametrize("return_train_score", [True, False])
     def test_cross_validate_train_error(self, return_train_score):
@@ -278,7 +282,7 @@ class TestCrossValidate:
             pipeline.run(data_point)
             return data_point.group_labels[0]
 
-        with pytest.raises(TestError) as e:
+        with pytest.raises(TestError, match="Testing failed") as e:
             cross_validate(
                 # We need to select any fold other than 0 as error fold to get the error triggered during training
                 DummyOptimize(CustomOptimizablePipelineWithRunError(error_fold=1)),
@@ -289,11 +293,11 @@ class TestCrossValidate:
             )
 
         if return_train_score:
-            assert "This error occurred in fold 0" in str(e.value)
-            assert "train-set" in str(e.value)
+            assert e.value.__notes__ == ["Context: cv_fold: index=0"]
+            assert e.value.__cause__.__notes__[0].startswith("Context: train_score:")
         else:
-            assert "This error occurred in fold 1" in str(e.value)
-            assert "test-set" in str(e.value)
+            assert e.value.__notes__ == ["Context: cv_fold: index=1"]
+            assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
 
     def test_cross_validate_optimizer_are_cloned(self):
         results = cross_validate(

--- a/tests/test_pipelines/test_validate.py
+++ b/tests/test_pipelines/test_validate.py
@@ -47,6 +47,12 @@ class CustomOptimizablePipelineWithRunError(OptimizablePipeline):
         return self
 
 
+class BrokenGroupLabelsDataset(DummyDataset):
+    @property
+    def group_labels(self):
+        raise RuntimeError("group labels failed")
+
+
 class TestValidate:
     @pytest.mark.parametrize(
         "kwargs",
@@ -79,6 +85,13 @@ class TestValidate:
         all_ids = np.array(ds.group_labels).flatten()
         assert all(np.array(result_row["data_labels"]).flatten() == np.array(result_row["single__score"]))
         assert result_row["agg__score"] == np.mean(all_ids)
+
+    def test_validate_wraps_group_label_context_error(self):
+        with pytest.raises(TestError, match="Testing failed") as e:
+            validate(DummyPipeline(), BrokenGroupLabelsDataset(), scoring=dummy_single_score_func)
+
+        assert str(e.value) == "Testing failed.\nContext: score"
+        assert isinstance(e.value.__cause__, RuntimeError)
 
     @pytest.mark.parametrize(
         "multiprocess_args",

--- a/tests/test_pipelines/test_validate.py
+++ b/tests/test_pipelines/test_validate.py
@@ -249,6 +249,7 @@ class TestCrossValidate:
                 cv=5,
             )
 
+        assert f"Context: cv_fold: index={error_fold} > optimize:" in str(e.value)
         assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
 
     @pytest.mark.parametrize("error_fold", [0, 2])
@@ -265,6 +266,7 @@ class TestCrossValidate:
                 cv=5,
             )
 
+        assert f"Context: cv_fold: index={error_fold} > test_score:" in str(e.value)
         assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
         assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
         assert e.value.__cause__.__cause__.__notes__ == [
@@ -293,9 +295,11 @@ class TestCrossValidate:
             )
 
         if return_train_score:
+            assert "Context: cv_fold: index=0 > train_score:" in str(e.value)
             assert e.value.__notes__ == ["Context: cv_fold: index=0"]
             assert e.value.__cause__.__notes__[0].startswith("Context: train_score:")
         else:
+            assert "Context: cv_fold: index=1 > test_score:" in str(e.value)
             assert e.value.__notes__ == ["Context: cv_fold: index=1"]
             assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
 


### PR DESCRIPTION
## Summary

Fixes #130.

This adds a stackable `warning_error_context` helper that attaches structured context to warnings and exceptions, then uses it across scoring, validation, grid search, and Optuna trials.

Warning enrichment is installed at Python's warning-message dispatcher so it also covers pre-imported warning aliases, `warn_explicit`, C-originated warnings, and warning-recording contexts while preserving warning types and source locations. Developer-facing comments explain why this private dispatcher is the necessary interception level. The normal warning header remains unchanged and the contextual copy is rendered on a separate line.

The context interface accepts an optional fixed dictionary and/or a lazy `context_provider` callback. Providers are resolved at diagnostic time, so dynamic state such as Optuna trial parameters is current when the warning or error occurs. Provider and rendering failures cannot mask the original diagnostic.

The returned context can also be activated with `start()` and deactivated with `stop()` so a long top-level script does not need an extra indentation level. Manual `stop()` cannot observe, record, or annotate an active exception, and an exception that skips it leaves the context installed; the `with` form remains the recommended exception-safe interface.

Each entered context yields a persistent `WarningErrorContext`. Its `records` list contains `WarningErrorContextRecord(type, context, message)` entries for:

- warnings that reach Python's warning dispatcher;
- exceptions that escape a context;
- calls to the new `print_with_context` helper.

Records contain the fully resolved nested context and retain the original warning or exception object, enabling queries by concrete diagnostic class and datapoint metadata. Nested events are appended once to every active context result.

`print_with_context` supports the normal print controls. With active context it prepends the rendered context and records the original message; without active context it behaves like `print`.

An outer `record_only=True` context suppresses contextual warning forwarding and `print_with_context` output throughout nested contexts while continuing to record warning, print, and escaping-error events. It never swallows exceptions or ordinary print output. Python warning filters still run before recording, so callers that need every repeated occurrence can scope `warnings.simplefilter("always")`.

Iterator loop bodies use explicit context lifetimes and never leave context active across a generator `yield`:

- `iter_with_warning_error_context` pairs arbitrary iterable items with a context creator and injects the zero-based iteration index as `i`;
- `TypedIterator.warning_error_context` binds the same explicit interface to the current typed iteration;
- fixed context, provider-only context, and combined context are supported;
- no item metadata other than `i` is inferred.

The executable Sphinx-Gallery recipe covers fixed and dynamic context, nested contexts, errors, manual lifecycle control and its exception caveat, retained records, warning-class queries, contextual prints, quiet record-only execution, arbitrary iterators, `TypedIterator`, typed sub-iterations, repeated warning filters, and regular-plus-iterator context stacking.

On Python 3.9 and 3.10, exception context remains available through `__notes__`. Python's standard renderer does not display those notes on these versions, but compatible renderers such as Rich do. Tpcp-owned wrapper errors continue to include context directly in their messages.

The scorer wrapper also captures datapoint labels once and renders them defensively only on failure, so failing or unrenderable label metadata cannot mask the original scoring exception or add work to successful datapoints.

The repository compatibility policy from commit `4def938` is included. Compatibility is maintained against `main`; provisional interfaces introduced only within this unmerged PR were refined without compatibility shims.

## Validation

- `uv run pytest -q` → `594 passed, 11 skipped`
- `uv run poe docs` → succeeded; the changed gallery example executed successfully
- `uv run ruff check src/tpcp` → passed
- focused test and example lint checks → passed
- `uv run ruff format . --check` → passed
- `uv run pyright src/tpcp/misc/_warning_error_context.py` → passed
- Python 3.9 syntax compilation of changed source, example, and tests → passed
- `git diff --check` → passed
- final whole-stack Roborev review findings resolved; all related reviews closed


