### PR TITLE
Optimize Python CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,21 +6,25 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Install uv and python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
-        cache-dependency-glob: "uv.lock"
+        cache-dependency-glob: uv.lock
         python-version: "3.11"
     - name: Build package
       run: uv build
     - name: Publish package
-      run: |
-        uv publish dist/* -u "${{ secrets.PYPI_USERNAME }}" -p "${{ secrets.PYPI_PASSWORD }}"
+      run: uv publish dist/* -u "${{ secrets.PYPI_USERNAME }}" -p "${{ secrets.PYPI_PASSWORD }}"

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -6,32 +6,88 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  test_and_lint:
+  test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.14"]
+        include:
+        - python-version: "3.9"
+          all-extras: true
+          coverage: false
+        - python-version: "3.10"
+          all-extras: false
+          coverage: false
+        - python-version: "3.11"
+          all-extras: true
+          coverage: true
+        - python-version: "3.12"
+          all-extras: false
+          coverage: false
+        - python-version: "3.13"
+          all-extras: false
+          coverage: false
+        - python-version: "3.14"
+          all-extras: true
+          coverage: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Install uv and python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
-        cache-dependency-glob: "uv.lock"
+        cache-dependency-glob: uv.lock
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: uv sync --locked --all-extras --group dev
-    - name: Testing
-      run: |
-        uv run poe test
-    - name: Linting
-      if: ${{ matrix.python-version == '3.11' }}
-      run: |
-        uv run poe ci_check
-    - name: "Upload coverage to Codecov"
-      if: ${{ matrix.python-version == '3.11' }}
-      uses: codecov/codecov-action@v3
+    - name: Install test dependencies
+      if: matrix.all-extras == false
+      run: uv sync --locked --no-default-groups --group test
+    - name: Install test dependencies with optional integrations
+      if: matrix.all-extras == true && matrix.coverage == false
+      run: uv sync --locked --no-default-groups --group test --all-extras
+    - name: Install test and coverage dependencies
+      if: matrix.coverage == true
+      run: uv sync --locked --no-default-groups --group test --group coverage --all-extras
+    - name: Test without coverage
+      if: matrix.coverage == false
+      run: uv run --no-sync pytest tests -n 2 --dist=worksteal
+    - name: Test with coverage
+      if: matrix.coverage == true
+      run: uv run --no-sync pytest tests -n 2 --dist=worksteal --cov=tpcp --cov-report=xml
+    - name: Upload coverage to Codecov
+      if: matrix.coverage == true
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        disable_search: true
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - name: Install uv and python
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        enable-cache: true
+        cache-dependency-glob: uv.lock
+        python-version: "3.11"
+    - name: Install lint dependencies
+      run: uv sync --locked --no-default-groups --no-install-project --group lint
+    - name: Lint
+      run: uv run --no-sync ruff check src/tpcp --output-format=github
+    - name: Check formatting
+      run: uv run --no-sync ruff format . --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,22 @@ tpcp = "tpcp._cli:main"
 tpcp_snapshots = "tpcp.testing._regression_utils"
 
 [dependency-groups]
-dev = [
-    "pydata-sphinx-theme>=0.14.1,<0.15",
+test = [
+    "attrs>=22.1.0",
+    "matplotlib>=3.4.3,<4",
+    "numpydoc>=1.4.0,<2",
+    "optuna>=2.10",
     "pytest>=8.4.2,<9",
+    "pytest-xdist>=3.8.0,<4",
+]
+coverage = [
     "pytest-cov>=7.0.0,<8",
-    "poethepoet>=0.10.0,<0.11",
+]
+lint = [
+    "ruff>=0.14.0,<0.15",
+]
+docs = [
+    "pydata-sphinx-theme>=0.14.1,<0.15",
     "pyright>=1.1.230,<2",
     "numpydoc>=1.4.0,<2",
     "sphinx-gallery>=0.14.0,<0.15",
@@ -49,8 +60,13 @@ dev = [
     "matplotlib>=3.4.3,<4",
     "toml>=0.10.2,<0.11",
     "Sphinx>=7.2.6,<8",
-    "ruff>=0.14.0,<0.15",
-    "tensorflow-cpu>=2.18.0rc2,<3; python_full_version < '3.14'",
+]
+dev = [
+    { include-group = "test" },
+    { include-group = "coverage" },
+    { include-group = "lint" },
+    { include-group = "docs" },
+    "poethepoet>=0.10.0,<0.11",
 ]
 
 [tool.uv]
@@ -82,7 +98,7 @@ lint = { cmd = "ruff check src/tpcp --fix", help = "Lint all files with ruff." }
 _lint_ci = "ruff check src/tpcp --output-format=github"
 _check_format = "ruff format . --check"
 ci_check = { sequence = ["_check_format", "_lint_ci"], help = "Check all potential format and linting issues." }
-test = { cmd = "pytest ./tests --cov=tpcp --cov-report=term-missing --cov-report=xml", help = "Run Pytest with coverage." }
+test = { cmd = "pytest ./tests -n 2 --dist=worksteal --cov=tpcp --cov-report=term-missing --cov-report=xml", help = "Run Pytest with coverage." }
 docs = { "script" = "_tasks:task_docs()",  help = "Build the html docs using Sphinx." }
 docs_clean = { "script" = "_tasks:task_docs(clean=True)",  help = "Remove all old build files and build a clean version of the docs." }
 docs_preview = { cmd = "python -m http.server --directory docs/_build/html", help = "Preview the built html docs." }

--- a/uv.lock
+++ b/uv.lock
@@ -864,6 +864,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -3258,6 +3267,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4446,24 +4468,54 @@ x-torch-cpu = [
 ]
 
 [package.dev-dependencies]
+coverage = [
+    { name = "pytest-cov" },
+]
 dev = [
+    { name = "attrs" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
     { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
     { name = "memory-profiler" },
     { name = "numpydoc", version = "1.9.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
     { name = "numpydoc", version = "1.10.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
+    { name = "optuna" },
     { name = "poethepoet" },
     { name = "pydata-sphinx-theme" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "recommonmark" },
     { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-gallery" },
-    { name = "tensorflow-cpu", version = "2.20.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
-    { name = "tensorflow-cpu", version = "2.21.0rc0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10' and python_full_version < '3.14'" },
     { name = "toml" },
+]
+docs = [
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
+    { name = "memory-profiler" },
+    { name = "numpydoc", version = "1.9.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
+    { name = "numpydoc", version = "1.10.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydata-sphinx-theme" },
+    { name = "pyright" },
+    { name = "recommonmark" },
+    { name = "sphinx" },
+    { name = "sphinx-gallery" },
+    { name = "toml" },
+]
+lint = [
+    { name = "ruff" },
+]
+test = [
+    { name = "attrs" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpydoc", version = "1.9.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.10'" },
+    { name = "numpydoc", version = "1.10.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.10'" },
+    { name = "optuna" },
+    { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -4482,21 +4534,44 @@ requires-dist = [
 provides-extras = ["x-torch-cpu", "x-tensorflow", "optuna", "attrs"]
 
 [package.metadata.requires-dev]
+coverage = [{ name = "pytest-cov", specifier = ">=7.0.0,<8" }]
 dev = [
+    { name = "attrs", specifier = ">=22.1.0" },
     { name = "matplotlib", specifier = ">=3.4.3,<4" },
     { name = "memory-profiler", specifier = ">=0.58.0,<0.59" },
     { name = "numpydoc", specifier = ">=1.4.0,<2" },
+    { name = "optuna", specifier = ">=2.10" },
     { name = "poethepoet", specifier = ">=0.10.0,<0.11" },
     { name = "pydata-sphinx-theme", specifier = ">=0.14.1,<0.15" },
     { name = "pyright", specifier = ">=1.1.230,<2" },
     { name = "pytest", specifier = ">=8.4.2,<9" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<4" },
     { name = "recommonmark", specifier = ">=0.7.1,<0.8" },
     { name = "ruff", specifier = ">=0.14.0,<0.15" },
     { name = "sphinx", specifier = ">=7.2.6,<8" },
     { name = "sphinx-gallery", specifier = ">=0.14.0,<0.15" },
-    { name = "tensorflow-cpu", marker = "python_full_version < '3.14'", specifier = ">=2.18.0rc2,<3" },
     { name = "toml", specifier = ">=0.10.2,<0.11" },
+]
+docs = [
+    { name = "matplotlib", specifier = ">=3.4.3,<4" },
+    { name = "memory-profiler", specifier = ">=0.58.0,<0.59" },
+    { name = "numpydoc", specifier = ">=1.4.0,<2" },
+    { name = "pydata-sphinx-theme", specifier = ">=0.14.1,<0.15" },
+    { name = "pyright", specifier = ">=1.1.230,<2" },
+    { name = "recommonmark", specifier = ">=0.7.1,<0.8" },
+    { name = "sphinx", specifier = ">=7.2.6,<8" },
+    { name = "sphinx-gallery", specifier = ">=0.14.0,<0.15" },
+    { name = "toml", specifier = ">=0.10.2,<0.11" },
+]
+lint = [{ name = "ruff", specifier = ">=0.14.0,<0.15" }]
+test = [
+    { name = "attrs", specifier = ">=22.1.0" },
+    { name = "matplotlib", specifier = ">=3.4.3,<4" },
+    { name = "numpydoc", specifier = ">=1.4.0,<2" },
+    { name = "optuna", specifier = ">=2.10" },
+    { name = "pytest", specifier = ">=8.4.2,<9" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<4" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- split test, coverage, lint, and docs dependency groups so each CI job installs only what it needs
- run the test suite with two pytest-xdist workers and collect coverage once
- retain optional-integration coverage on Python 3.9, 3.11, and 3.14 while using lean jobs for intermediate versions
- add Python 3.13, dependency caching, concurrency cancellation, timeouts, least-privilege permissions, SHA-pinned actions, and Dependabot updates
- harden the release workflow with pinned actions, read-only permissions, disabled persisted credentials, and a timeout

## Why

The existing matrix installed the full development environment and collected coverage on every Python version. That repeated expensive TensorFlow, Torch, documentation, lint, and coverage setup across all jobs and ran tests sequentially.

## Validation

- full Python 3.11 extras + coverage suite: 565 passed, 11 skipped
- minimal Python 3.13 suite: 545 passed, 13 skipped
- local minimal-suite timing: 68.9s sequential, 46.8s with two workers
- Ruff lint and formatting checks
- locked dependency validation
- workflow YAML parsing
- source distribution and wheel build
- GitHub Actions and Read the Docs checks pass

## Hosted CI timing

Compared with the median of the three most recent successful `main` runs:

| Metric | Main median | This PR | Change |
|---|---:|---:|---:|
| Workflow wall time | 3m 03s | 2m 45s | -10% |
| Aggregate runner time | 12m 56s | 8m 53s | -31% |
| Aggregate test-step time | 10m 53s | 6m 38s | -39% |
| Slowest test step | 2m 33s | 1m 51s | -27% |
| Jobs | 5 | 7 | +2 |

The PR run used a cold cache key because `uv.lock` changed, so the result does not depend on a pre-existing warm dependency cache.
