### PR TITLE
Add fold-local training dataset transforms

### DIFF
--- a/.agents/refactor-policy.md
+++ b/.agents/refactor-policy.md
@@ -1,0 +1,5 @@
+# Backwards-compatibility policy
+
+- **Backwards compatibility is mandatory** for all public interfaces and supported behavior; changes must be additive and non-breaking by default.
+- Internal interfaces may be refactored freely when all in-repository consumers are updated in the same change, provided no public behavior or interface is broken.
+- Public breaking changes require explicit user approval as a scoped exception, a clear migration path, and prominent flags in code review, changelogs, and delivery reports; reviewers must reject unapproved breaks.

--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,5 @@ _debug_test
 # joss paper compile output
 paper/paper.pdf
 paper/paper.jats
+# roborev snapshots
+/.roborev/

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,4 @@
+# Project-specific review guidelines
+review_guidelines = """
+Backwards compatibility is mandatory for all public interfaces and supported behavior; flag and reject unapproved breaking changes. Internal refactors may proceed when every in-repository consumer is updated and public behavior remains stable. A public breaking change is permitted only as an explicitly approved, scoped exception with a migration path and prominent communication in code review, changelogs, and delivery reports.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent guidance
+
+## Repository-local skills and refactoring
+
+- When the same skill name is available from multiple locations, always use the repository-local skill under `$REPO_ROOT/.agents/skills/`. Repository-local skills take precedence over user-global skills. Do not load or apply the corresponding skill from `$HOME/.agents/skills/` when a repository-local version exists.
+- Consider the repository's current publication state and backwards-compatibility requirements recorded in `.agents/refactor-policy.md` in all interactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an optional `train_dataset_transform` callable to `Optimize` and `GridSearchCV` for fold-local training-data
+  augmentation and subsampling.
+  (https://github.com/mad-lab-fau/tpcp/pull/137)
 - Added an advanced recipe showing how to expose predefined parameters and pretrained models for algorithms.
   (https://github.com/mad-lab-fau/tpcp/pull/133)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional `train_dataset_transform` callable to `Optimize` and `GridSearchCV` for fold-local training-data
   augmentation and subsampling.
   (https://github.com/mad-lab-fau/tpcp/pull/137)
+- Added `DatasetWrapperMixin` to implement datasets that lazily transform another dataset while preserving a shared
+  domain-specific dataset interface.
+  (https://github.com/mad-lab-fau/tpcp/pull/137)
 - Added an advanced recipe showing how to expose predefined parameters and pretrained models for algorithms.
   (https://github.com/mad-lab-fau/tpcp/pull/133)
 

--- a/docs/guides/algorithms_pipelines_datasets.rst
+++ b/docs/guides/algorithms_pipelines_datasets.rst
@@ -70,6 +70,19 @@ like :func:`~tpcp.validate.cross_validate`.
    It is up to the user to add additional methods and properties to a dataset that represent the actual data that can
    be used by an algorithm.
 
+Datasets that lazily transform or augment another dataset can reuse :class:`~tpcp.DatasetWrapperMixin`. Such a wrapper
+inherits from both the mixin and the shared domain-specific dataset base, allowing original and transformed datapoints
+to expose the same properties to a Pipeline.
+
+.. important::
+   For a wrapped dataset, always list :class:`~tpcp.DatasetWrapperMixin` **before** the domain-specific dataset base::
+
+       class AugmentedDataset(DatasetWrapperMixin[DomainDataset], DomainDataset):
+           ...
+
+   This order is required by Python's method resolution order. Reversing the bases would select the dataset base's
+   index implementation instead of the wrapper implementation and is rejected with a :class:`TypeError`.
+
 
 
 Pipelines

--- a/docs/modules/dataset.rst
+++ b/docs/modules/dataset.rst
@@ -15,3 +15,27 @@ Classes
    :template: class.rst
 
     Dataset
+    DatasetWrapperMixin
+
+
+Wrapping datasets
+-----------------
+
+:class:`~tpcp.DatasetWrapperMixin` contains the common implementation for datasets that wrap another dataset while
+preserving a shared domain-specific dataset interface. It expands the wrapped index, derives the wrapper's initial
+grouping, and resolves the wrapped datapoint represented by each wrapper datapoint.
+
+Because the mixin does not inherit from :class:`~tpcp.Dataset`, wrapper classes combine it with their domain-specific
+dataset base::
+
+    class AugmentedImageDataset(
+        DatasetWrapperMixin[ImageDataset],
+        ImageDataset,
+    ):
+        ...
+
+.. important::
+   The inheritance order is required. ``DatasetWrapperMixin`` must be the first base and the domain-specific dataset
+   must be the second base. Reversing them changes Python's method resolution order, preventing the mixin's
+   ``create_index`` implementation from taking precedence. TPCP raises a :class:`TypeError` when it detects the reversed
+   order.

--- a/examples/validation/_05_train_dataset_transform.py
+++ b/examples/validation/_05_train_dataset_transform.py
@@ -1,0 +1,309 @@
+r"""
+Transforming training datasets
+==============================
+
+Some optimization workflows need a different *set of datapoints* during training without changing the interface
+expected by the pipeline. Data augmentation can multiply datapoints, while a quick smoke test might train on only a
+small subset. Both operations must happen after a cross-validation fold is split so related augmented data can never
+leak into the test set.
+
+This example demonstrates both cases using ``train_dataset_transform``. A transform is simply a callable receiving a
+dataset and returning a dataset that implements the same interface. The pipeline remains generic over one common
+dataset type and can handle original and transformed datapoints identically.
+"""
+
+# %%
+# A shared image-dataset interface
+# --------------------------------
+# The raw and augmented datasets use different concrete classes, but implement the same properties defined by
+# ``ImageDataset``. The augmented dataset wraps the original dataset instead of copying its data. It proxies the
+# label and source image through that wrapped dataset, applying only the rotation itself. Consequently, an augmented
+# datapoint can be passed anywhere an original datapoint can be passed.
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from tpcp import Dataset
+
+
+class ImageDataset(Dataset):
+    """Common interface for raw and augmented image datasets."""
+
+    @property
+    def image(self) -> np.ndarray:
+        """Load the image represented by a single datapoint."""
+        raise NotImplementedError
+
+    @property
+    def label(self) -> int:
+        """Return the classification label of a single datapoint."""
+        raise NotImplementedError
+
+
+class RawImageDataset(ImageDataset):
+    """Dataset containing the original images and labels."""
+
+    def __init__(
+        self,
+        images: np.ndarray,
+        labels: np.ndarray,
+        *,
+        groupby_cols: Optional[Union[list[str], str]] = None,
+        subset_index: Optional[pd.DataFrame] = None,
+    ) -> None:
+        self.images = images
+        self.labels = labels
+        super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
+
+    def create_index(self) -> pd.DataFrame:
+        """Create one datapoint per source image."""
+        return pd.DataFrame(
+            [
+                (sample_id, int(label))
+                for sample_id, label in enumerate(self.labels)
+            ],
+            columns=["sample_id", "label"],
+        )
+
+    @property
+    def image(self) -> np.ndarray:
+        """Load a single original image."""
+        self.assert_is_single(None, "image")
+        row = self.index.iloc[0]
+        return self.images[int(row["sample_id"])]
+
+    @property
+    def label(self) -> int:
+        """Return the original image's classification label."""
+        self.assert_is_single(None, "label")
+        return int(self.index.iloc[0]["label"])
+
+
+class AugmentedImageDataset(ImageDataset):
+    """Dataset wrapping an image dataset and exposing lazily rotated datapoints."""
+
+    def __init__(
+        self,
+        original_dataset: ImageDataset,
+        rotation_degrees: tuple[int, ...] = (0, 90, 180, 270),
+        *,
+        groupby_cols: Optional[Union[list[str], str]] = None,
+        subset_index: Optional[pd.DataFrame] = None,
+    ) -> None:
+        self.original_dataset = original_dataset
+        self.rotation_degrees = rotation_degrees
+        super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
+
+    def create_index(self) -> pd.DataFrame:
+        """Add an augmentation dimension to the wrapped dataset's index."""
+        return (
+            pd.concat(
+                [
+                    self.original_dataset.index.assign(rotation_deg=rotation)
+                    for rotation in self.rotation_degrees
+                ],
+                ignore_index=True,
+            )
+            .sort_values([*self.original_dataset.index.columns, "rotation_deg"])
+            .reset_index(drop=True)
+        )
+
+    @property
+    def _original_datapoint(self) -> ImageDataset:
+        """Resolve the original datapoint represented by a single augmented row."""
+        self.assert_is_single(self.groupby_cols, "_original_datapoint")
+        original_index = self.index.drop(columns="rotation_deg")
+        return self.original_dataset.get_subset(index=original_index)
+
+    @property
+    def image(self) -> np.ndarray:
+        """Proxy the original image and apply the rotation encoded in the index."""
+        self.assert_is_single(self.groupby_cols, "image")
+        rotation_degrees = int(self.index.iloc[0]["rotation_deg"])
+        return np.rot90(
+            self._original_datapoint.image, k=rotation_degrees // 90
+        ).copy()
+
+    @property
+    def label(self) -> int:
+        """Proxy the label of the wrapped original datapoint."""
+        return self._original_datapoint.label
+
+
+# %%
+# We use a tiny in-memory image dataset to keep the example fast. The first class contains variants of an L-like
+# shape, while the second contains variants of a T-like shape.
+images = np.asarray(
+    [
+        [[1, 0, 0], [1, 1, 0], [1, 0, 0]],
+        [[1, 0, 0], [1, 0, 0], [1, 1, 0]],
+        [[1, 1, 0], [1, 0, 0], [1, 0, 0]],
+        [[1, 1, 1], [0, 1, 0], [0, 1, 0]],
+        [[1, 1, 1], [1, 0, 1], [0, 1, 0]],
+        [[0, 1, 0], [1, 1, 1], [0, 1, 0]],
+    ],
+    dtype=float,
+)
+labels = np.asarray([0, 0, 0, 1, 1, 1])
+raw_dataset = RawImageDataset(images, labels)
+
+
+# %%
+# Real augmentation: rotate images
+# --------------------------------
+# The transform receives only the training subset created for a fold. The augmented dataset stores that subset as its
+# ``original_dataset`` parameter and builds its expanded index from it. Data and reference properties are resolved
+# through the wrapped subset only when the pipeline accesses an individual datapoint.
+def rotate_training_images(dataset: ImageDataset) -> AugmentedImageDataset:
+    """Add 90, 180, and 270 degree rotations of every provided datapoint."""
+    if dataset.groupby_cols is None:
+        augmented_groupby_cols = None
+    else:
+        original_groupby_cols = (
+            [dataset.groupby_cols]
+            if isinstance(dataset.groupby_cols, str)
+            else dataset.groupby_cols
+        )
+        augmented_groupby_cols = [*original_groupby_cols, "rotation_deg"]
+    return AugmentedImageDataset(dataset, groupby_cols=augmented_groupby_cols)
+
+
+augmented_dataset = rotate_training_images(raw_dataset)
+
+# %%
+# Accessing a rotated datapoint uses exactly the same ``image`` and ``label`` properties as accessing an original.
+rotations = [
+    augmented_dataset.get_subset(
+        index=pd.DataFrame(
+            augmented_dataset.index.loc[
+                (augmented_dataset.index["sample_id"] == 0)
+                & (augmented_dataset.index["rotation_deg"] == angle)
+            ]
+        )
+    )
+    for angle in (0, 90, 180, 270)
+]
+fig, axes = plt.subplots(1, 4, figsize=(7, 2))
+for datapoint, angle, axis in zip(rotations, (0, 90, 180, 270), axes):
+    axis.imshow(datapoint.image, cmap="gray", vmin=0, vmax=1)
+    axis.set_title(f"{angle}°")
+    axis.axis("off")
+fig.tight_layout()
+
+# %%
+# A pipeline that handles both dataset classes
+# ---------------------------------------------
+# This deliberately small nearest-neighbour classifier stores the images it receives during optimization. Its only
+# dataset type is ``ImageDataset``; it has no augmentation-specific logic.
+from tpcp import OptimizableParameter, OptimizablePipeline
+
+
+class ImageClassificationPipeline(OptimizablePipeline[ImageDataset]):
+    """A minimal nearest-neighbour image classifier."""
+
+    training_images: OptimizableParameter[Optional[np.ndarray]]
+    training_labels: OptimizableParameter[Optional[np.ndarray]]
+
+    prediction_: int
+
+    def __init__(
+        self,
+        training_images: Optional[np.ndarray] = None,
+        training_labels: Optional[np.ndarray] = None,
+    ) -> None:
+        self.training_images = training_images
+        self.training_labels = training_labels
+
+    def self_optimize(self, dataset: ImageDataset, **_: object):
+        """Remember all provided images as nearest-neighbour training samples."""
+        self.training_images = np.stack(
+            [datapoint.image for datapoint in dataset]
+        )
+        self.training_labels = np.asarray(
+            [datapoint.label for datapoint in dataset]
+        )
+        return self
+
+    def run(self, datapoint: ImageDataset):
+        """Classify an original or augmented datapoint."""
+        if self.training_images is None or self.training_labels is None:
+            raise RuntimeError(
+                "The pipeline must be optimized before it can classify images."
+            )
+        distances = np.linalg.norm(
+            self.training_images - datapoint.image, axis=(1, 2)
+        )
+        self.prediction_ = int(self.training_labels[np.argmin(distances)])
+        return self
+
+
+def accuracy(
+    pipeline: ImageClassificationPipeline, datapoint: ImageDataset
+) -> float:
+    """Score one image."""
+    return float(pipeline.safe_run(datapoint).prediction_ == datapoint.label)
+
+
+# %%
+# Fold-local augmentation
+# -----------------------
+# ``cross_validate`` first creates the untouched train and test subsets. ``Optimize`` then transforms only the train
+# subset immediately before ``self_optimize``. The scorer therefore continues to evaluate original images.
+from sklearn.model_selection import StratifiedKFold
+from tpcp.optimize import Optimize
+from tpcp.validate import DatasetSplitter, cross_validate
+
+cv = DatasetSplitter(StratifiedKFold(n_splits=3), stratify="label")
+
+augmentation_results = cross_validate(
+    Optimize(
+        ImageClassificationPipeline(),
+        train_dataset_transform=rotate_training_images,
+    ),
+    raw_dataset,
+    scoring=accuracy,
+    cv=cv,
+    return_optimizer=True,
+    progress_bar=False,
+)
+augmentation_training_sizes = [
+    len(optimizer.transformed_dataset_)
+    for optimizer in augmentation_results["optimizer"]
+]
+print(augmentation_training_sizes)
+
+
+# %%
+# Subsampling for a smoke test
+# ----------------------------
+# A smoke-test transform follows the same interface. Here we keep one training datapoint per class, reducing every
+# fold from four training images to two while leaving its two scored test images untouched.
+def subsample_for_smoke_test(dataset: ImageDataset) -> ImageDataset:
+    """Keep one datapoint per class for a fast end-to-end check."""
+    smoke_test_index = dataset.index.groupby(
+        "label", sort=True, as_index=False
+    ).head(1)
+    return dataset.get_subset(index=smoke_test_index)
+
+
+smoke_test_results = cross_validate(
+    Optimize(
+        ImageClassificationPipeline(),
+        train_dataset_transform=subsample_for_smoke_test,
+    ),
+    raw_dataset,
+    scoring=accuracy,
+    cv=cv,
+    return_optimizer=True,
+    progress_bar=False,
+)
+smoke_test_training_sizes = [
+    len(optimizer.transformed_dataset_)
+    for optimizer in smoke_test_results["optimizer"]
+]
+print(smoke_test_training_sizes)
+
+# %%
+# The important distinction is visible in both result sets: the optimizer sees the transformed training dataset, but
+# ``test__data_labels`` and all reported test scores still refer to the original datapoints.

--- a/examples/validation/_05_train_dataset_transform.py
+++ b/examples/validation/_05_train_dataset_transform.py
@@ -24,7 +24,7 @@ from typing import Optional, Union
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from tpcp import Dataset
+from tpcp import Dataset, DatasetWrapperMixin
 
 
 class ImageDataset(Dataset):
@@ -80,55 +80,70 @@ class RawImageDataset(ImageDataset):
         return int(self.index.iloc[0]["label"])
 
 
-class AugmentedImageDataset(ImageDataset):
-    """Dataset wrapping an image dataset and exposing lazily rotated datapoints."""
+# %%
+# A reusable dataset wrapper
+# --------------------------
+# ``DatasetWrapperMixin`` handles the mechanics shared by datasets that wrap other datasets: it derives the initial
+# grouping from the wrapped dataset, materializes the expanded index, and resolves the wrapped datapoint represented by
+# an augmented datapoint.
+#
+# .. important::
+#    The inheritance order is essential: ``DatasetWrapperMixin`` must be listed **before** ``ImageDataset``. Python
+#    resolves methods from left to right, so reversing the bases would select the original ``Dataset.create_index``
+#    instead of the implementation supplied by the mixin. TPCP detects the reversed order when the class is defined and
+#    raises a ``TypeError`` with an explanation.
+class AugmentedImageDataset(
+    DatasetWrapperMixin[ImageDataset],
+    ImageDataset,
+):
+    """Dataset wrapping an image dataset and exposing lazily rotated datapoints.
+
+    ``DatasetWrapperMixin`` must remain the first base class so its index implementation takes precedence.
+    """
+
+    _wrapper_groupby_cols = ("rotation_deg",)
 
     def __init__(
         self,
-        original_dataset: ImageDataset,
+        wrapped_dataset: ImageDataset,
         rotation_degrees: tuple[int, ...] = (0, 90, 180, 270),
         *,
         groupby_cols: Optional[Union[list[str], str]] = None,
         subset_index: Optional[pd.DataFrame] = None,
     ) -> None:
-        self.original_dataset = original_dataset
+        self.wrapped_dataset = wrapped_dataset
         self.rotation_degrees = rotation_degrees
         super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
 
-    def create_index(self) -> pd.DataFrame:
+    def _create_wrapped_index(self, source_index: pd.DataFrame) -> pd.DataFrame:
         """Add an augmentation dimension to the wrapped dataset's index."""
+        rotation_col = self._wrapper_groupby_cols[0]
         return (
             pd.concat(
                 [
-                    self.original_dataset.index.assign(rotation_deg=rotation)
+                    source_index.assign(**{rotation_col: rotation})
                     for rotation in self.rotation_degrees
                 ],
                 ignore_index=True,
             )
-            .sort_values([*self.original_dataset.index.columns, "rotation_deg"])
+            .sort_values([*source_index.columns, rotation_col])
             .reset_index(drop=True)
         )
-
-    @property
-    def _original_datapoint(self) -> ImageDataset:
-        """Resolve the original datapoint represented by a single augmented row."""
-        self.assert_is_single(self.groupby_cols, "_original_datapoint")
-        original_index = self.index.drop(columns="rotation_deg")
-        return self.original_dataset.get_subset(index=original_index)
 
     @property
     def image(self) -> np.ndarray:
         """Proxy the original image and apply the rotation encoded in the index."""
         self.assert_is_single(self.groupby_cols, "image")
-        rotation_degrees = int(self.index.iloc[0]["rotation_deg"])
+        rotation_col = self._wrapper_groupby_cols[0]
+        rotation_degrees = int(self.index.iloc[0][rotation_col])
         return np.rot90(
-            self._original_datapoint.image, k=rotation_degrees // 90
+            self.wrapped_datapoint.image, k=rotation_degrees // 90
         ).copy()
 
     @property
     def label(self) -> int:
         """Proxy the label of the wrapped original datapoint."""
-        return self._original_datapoint.label
+        return self.wrapped_datapoint.label
 
 
 # %%
@@ -153,20 +168,11 @@ raw_dataset = RawImageDataset(images, labels)
 # Real augmentation: rotate images
 # --------------------------------
 # The transform receives only the training subset created for a fold. The augmented dataset stores that subset as its
-# ``original_dataset`` parameter and builds its expanded index from it. Data and reference properties are resolved
+# ``wrapped_dataset`` parameter and builds its expanded index from it. Data and reference properties are resolved
 # through the wrapped subset only when the pipeline accesses an individual datapoint.
 def rotate_training_images(dataset: ImageDataset) -> AugmentedImageDataset:
     """Add 90, 180, and 270 degree rotations of every provided datapoint."""
-    if dataset.groupby_cols is None:
-        augmented_groupby_cols = None
-    else:
-        original_groupby_cols = (
-            [dataset.groupby_cols]
-            if isinstance(dataset.groupby_cols, str)
-            else dataset.groupby_cols
-        )
-        augmented_groupby_cols = [*original_groupby_cols, "rotation_deg"]
-    return AugmentedImageDataset(dataset, groupby_cols=augmented_groupby_cols)
+    return AugmentedImageDataset(dataset.clone())
 
 
 augmented_dataset = rotate_training_images(raw_dataset)

--- a/src/tpcp/__init__.py
+++ b/src/tpcp/__init__.py
@@ -11,7 +11,7 @@ from tpcp._algorithm_utils import (
     make_optimize_safe,
 )
 from tpcp._base import NOTHING, BaseFactory, BaseTpcpObject, CloneFactory, cf, clone, get_param_names
-from tpcp._dataset import Dataset
+from tpcp._dataset import Dataset, DatasetWrapperMixin
 from tpcp._parameters import (
     HyperPara,
     HyperParameter,
@@ -34,6 +34,7 @@ __all__ = [
     "BaseTpcpObject",
     "CloneFactory",
     "Dataset",
+    "DatasetWrapperMixin",
     "HyperPara",
     "HyperParameter",
     "OptiPara",

--- a/src/tpcp/_dataset.py
+++ b/src/tpcp/_dataset.py
@@ -3,7 +3,7 @@
 import warnings
 from collections.abc import Iterator, Sequence
 from keyword import iskeyword
-from typing import Generic, Optional, TypeVar, Union, cast, get_args, overload
+from typing import ClassVar, Generic, Optional, TypeVar, Union, cast, get_args, get_origin, overload
 
 import numpy as np
 import pandas as pd
@@ -125,7 +125,7 @@ class _Dataset(BaseTpcpObject, Generic[GroupLabelT]):
             )
 
         # Get the generic type of the dataset
-        group_label_type = get_args(type(self).__orig_bases__[0])[0]
+        group_label_type = self._get_group_label_type()
         # If group label type is a named tuple, we check that the keys are the same as the index columns
         if (label_fields := getattr(group_label_type, "_fields", None)) and label_fields != (
             index_cols := tuple(index_1.columns)
@@ -155,7 +155,7 @@ class _Dataset(BaseTpcpObject, Generic[GroupLabelT]):
 
         For some examples and additional explanation see this :ref:`example <custom_dataset_basics>`.
         """
-        if getattr(group_label_type := get_args(type(self).__orig_bases__[0])[0], "_fields", None):
+        if getattr(group_label_type := self._get_group_label_type(), "_fields", None):
             nd_tuple_name = group_label_type.__name__
         else:
             nd_tuple_name = type(self).__name__ + "GroupLabel"
@@ -198,7 +198,7 @@ class _Dataset(BaseTpcpObject, Generic[GroupLabelT]):
 
     def index_as_tuples(self) -> list[GroupLabelT]:
         """Get all datapoint labels of the dataset (i.e. a list of the rows of the index as named tuples)."""
-        if getattr(group_label_type := get_args(type(self).__orig_bases__[0])[0], "_fields", None):
+        if getattr(group_label_type := self._get_group_label_type(), "_fields", None):
             # If a generic is provided, we actually convert the named tuples.
             return [group_label_type(*row) for row in self.index.itertuples(index=False)]
         return list(self.index.itertuples(index=False, name=type(self).__name__ + "GroupLabel"))
@@ -240,6 +240,15 @@ class _Dataset(BaseTpcpObject, Generic[GroupLabelT]):
         if self.groupby_cols is None:
             return index.columns.to_list()
         return _ensure_is_list(self.groupby_cols)
+
+    def _get_group_label_type(self):
+        """Find the concrete group-label type in the dataset inheritance hierarchy."""
+        for cls in type(self).__mro__:
+            for generic_base in getattr(cls, "__orig_bases__", ()):
+                origin = get_origin(generic_base)
+                if isinstance(origin, type) and issubclass(origin, _Dataset) and (args := get_args(generic_base)):
+                    return args[0]
+        return None
 
     def _get_unique_groups(self) -> Union[pd.MultiIndex, pd.Index]:
         return self.grouped_index.index.unique()
@@ -750,6 +759,81 @@ class Dataset(_Dataset[GroupLabelT], Generic[GroupLabelT]):
             subset_index: Optional[pd.DataFrame] = None
 
         return DatasetAt
+
+
+WrappedDatasetT = TypeVar("WrappedDatasetT", bound="_Dataset")
+
+
+class DatasetWrapperMixin(Generic[WrappedDatasetT]):
+    """Provide common behavior for datasets that wrap another dataset.
+
+    This mixin expands the index of ``wrapped_dataset`` through
+    :meth:`_create_wrapped_index`, links the wrapper's initial grouping to the
+    wrapped dataset, and resolves the source datapoint represented by a wrapper
+    datapoint through :attr:`wrapped_datapoint`.
+
+    The mixin deliberately does not inherit from :class:`Dataset`. A concrete
+    wrapper must inherit from both this mixin and the domain-specific dataset
+    interface implemented by the wrapped dataset.
+
+    .. important::
+        ``DatasetWrapperMixin`` must be listed **before** the dataset base class.
+        The order controls Python's method resolution order and ensures that this
+        mixin's :meth:`create_index` implementation is used. Reversing the bases
+        raises a :class:`TypeError` when the wrapper class is defined.
+
+    Examples
+    --------
+    The mixin comes first and the shared dataset interface comes second::
+
+        class AugmentedDataset(
+            DatasetWrapperMixin[SourceDataset],
+            SourceDataset,
+        ):
+            _wrapper_groupby_cols = ("augmentation",)
+
+            def _create_wrapped_index(self, source_index): ...
+
+    """
+
+    wrapped_dataset: WrappedDatasetT
+    _wrapper_groupby_cols: ClassVar[tuple[str, ...]]
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Validate that the mixin precedes the dataset base in the MRO."""
+        super().__init_subclass__(**kwargs)
+        mro = cls.__mro__
+        if _Dataset in mro and mro.index(DatasetWrapperMixin) > mro.index(_Dataset):
+            raise TypeError(
+                "DatasetWrapperMixin must be listed before the Dataset base class so its create_index method takes "
+                "precedence in the method resolution order."
+            )
+
+    def create_index(self) -> pd.DataFrame:
+        """Create the wrapper index and link its initial grouping to the wrapped dataset."""
+        source_index = self.wrapped_dataset.index.copy()
+        dataset = cast("_Dataset", self)
+
+        if dataset.groupby_cols is None:
+            dataset.groupby_cols = [*self.wrapped_dataset._get_groupby_columns(), *self._wrapper_groupby_cols]
+
+        return self._create_wrapped_index(source_index)
+
+    def _create_wrapped_index(self, source_index: pd.DataFrame) -> pd.DataFrame:
+        """Create the wrapper index from a copy of the wrapped dataset index."""
+        raise NotImplementedError
+
+    @property
+    def wrapped_datapoint(self) -> WrappedDatasetT:
+        """Return the wrapped datapoint represented by the current wrapper group."""
+        dataset = cast("_Dataset", self)
+        dataset.assert_is_single_group("wrapped_datapoint")
+
+        source_columns = self.wrapped_dataset.index.columns.to_list()
+        source_index = pd.DataFrame(dataset.index.loc[:, source_columns]).drop_duplicates().reset_index(drop=True)
+        source_groupby = [column for column in dataset._get_groupby_columns() if column in source_columns]
+
+        return self.wrapped_dataset.get_subset(index=source_index).groupby(source_groupby or None)
 
 
 T = TypeVar("T")

--- a/src/tpcp/_dataset.py
+++ b/src/tpcp/_dataset.py
@@ -234,9 +234,11 @@ class _Dataset(BaseTpcpObject, Generic[GroupLabelT]):
             ) from e
 
     def _get_groupby_columns(self) -> list[str]:
-        """Get the groupby columns."""
+        """Get the groupby columns after materializing the dataset index."""
+        # `create_index` may establish the grouping based on the materialized index.
+        index = self.index
         if self.groupby_cols is None:
-            return self.index.columns.to_list()
+            return index.columns.to_list()
         return _ensure_is_list(self.groupby_cols)
 
     def _get_unique_groups(self) -> Union[pd.MultiIndex, pd.Index]:

--- a/src/tpcp/optimize/_optimize.py
+++ b/src/tpcp/optimize/_optimize.py
@@ -11,6 +11,7 @@ from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Generic,
     Literal,
     Optional,
@@ -145,6 +146,26 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
     ----------
     pipeline
         The pipeline to optimize. The pipeline must implement `self_optimize` to optimize its own input parameters.
+    train_dataset_transform
+        An optional callable that transforms the dataset immediately before it is passed to the pipeline's
+        `self_optimize` method. The callable must return a dataset implementing the same interface as its input.
+        This can be used for operations such as data augmentation or subsampling. The callable receives a clone so
+        that in-place transformations cannot modify the original dataset.
+
+        For example, this transform restricts optimization to the first ten datapoints::
+
+            def first_ten(dataset):
+                return dataset[:10]
+
+
+            optimizer = Optimize(
+                pipeline,
+                train_dataset_transform=first_ten,
+            )
+            optimizer.optimize(dataset)
+
+        See :ref:`sphx_glr_auto_examples_validation__05_train_dataset_transform.py` for complete augmentation and
+        subsampling examples.
     safe_optimize
         If True, we add additional checks to make sure the `self_optimize` method of the pipeline is correctly
         implemented.
@@ -167,24 +188,31 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
     optimization_info_
         If the optimized pipeline implements a `self_optimize_with_info` method, this parameter contains the
         additional information provided as second return value from this method.
+    transformed_dataset_
+        The dataset used for optimization after applying `train_dataset_transform`. If no transform was supplied,
+        this is the original dataset.
 
     """
 
     pipeline: Parameter[OptimizablePipelineT]
+    train_dataset_transform: Optional[Callable[[DatasetT], DatasetT]]
     safe_optimize: bool
     optimize_with_info: bool
 
     optimized_pipeline_: OptimizablePipelineT
     optimization_info_: Any
+    transformed_dataset_: DatasetT
 
     def __init__(
         self,
         pipeline: OptimizablePipelineT,
         *,
+        train_dataset_transform: Optional[Callable[[DatasetT], DatasetT]] = None,
         safe_optimize: bool = True,
         optimize_with_info: bool = True,
     ) -> None:
         self.pipeline = pipeline
+        self.train_dataset_transform = train_dataset_transform
         self.safe_optimize = safe_optimize
         self.optimize_with_info = optimize_with_info
 
@@ -210,6 +238,10 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
 
         """
         self.dataset = dataset
+        transformed_dataset = (
+            self.train_dataset_transform(dataset.clone()) if self.train_dataset_transform is not None else dataset
+        )
+        self.transformed_dataset_ = transformed_dataset
         if not hasattr(self.pipeline, "self_optimize"):
             raise ValueError(
                 "To use `Optimize` with a pipeline, the pipeline needs to implement a `self_optimize` method."
@@ -220,13 +252,13 @@ class Optimize(BaseOptimize[OptimizablePipelineT, DatasetT]):
         if self.safe_optimize is True:
             # We check here, if the pipeline already has the safe decorator and if yes just call it.
             if getattr(method, OPTIMIZE_METHOD_INDICATOR, False) is True:
-                optimized_pipeline, other_info = _split_returns(method(dataset, **optimize_params))
+                optimized_pipeline, other_info = _split_returns(method(transformed_dataset, **optimize_params))
             else:
                 optimized_pipeline, other_info = _split_returns(
-                    _check_safe_optimize(pipeline, method, dataset, **optimize_params)
+                    _check_safe_optimize(pipeline, method, transformed_dataset, **optimize_params)
                 )
         else:
-            optimized_pipeline, other_info = _split_returns(method(dataset, **optimize_params))
+            optimized_pipeline, other_info = _split_returns(method(transformed_dataset, **optimize_params))
         # We clone again, just to be sure
         self.optimized_pipeline_ = optimized_pipeline.clone()
         if self.optimize_with_info and other_info is not NOTHING:
@@ -540,6 +572,28 @@ class GridSearchCV(
         <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html>`_.
 
         For more complex usecases like grouping or stratification, the :class:`~tpcp.TpcpSplitter` can be used.
+    train_dataset_transform
+        An optional callable that transforms each training dataset after splitting and immediately before
+        `self_optimize` is called. The callable must return a dataset implementing the same interface as its input.
+        Validation datasets remain unchanged. The transform is also applied before the final optimization on all data.
+
+        For example, this applies a smoke-test subsample independently to every training fold::
+
+            def first_ten(dataset):
+                return dataset[:10]
+
+
+            search = GridSearchCV(
+                pipeline,
+                parameter_grid,
+                scoring=scorer,
+                cv=5,
+                train_dataset_transform=first_ten,
+            )
+            search.optimize(dataset)
+
+        See :ref:`sphx_glr_auto_examples_validation__05_train_dataset_transform.py` for complete augmentation and
+        subsampling examples.
     pure_parameters
         .. warning::
             Do not use this option unless you fully understand it!
@@ -658,6 +712,7 @@ class GridSearchCV(
     scoring: ScorerTypes[OptimizablePipelineT, DatasetT]
     return_optimized: Union[bool, str]
     cv: Optional[Union[DatasetSplitter, int, BaseCrossValidator, Iterator]]
+    train_dataset_transform: Optional[Callable[[DatasetT], DatasetT]]
     pure_parameters: Union[bool, list[str]]
     return_train_score: bool
     verbose: int
@@ -682,6 +737,7 @@ class GridSearchCV(
         scoring: ScorerTypes[OptimizablePipelineT, DatasetT],
         return_optimized: Union[bool, str] = True,
         cv: Optional[Union[int, BaseCrossValidator, Iterator]] = None,
+        train_dataset_transform: Optional[Callable[[DatasetT], DatasetT]] = None,
         pure_parameters: Union[bool, list[str]] = False,
         return_train_score: bool = False,
         verbose: int = 0,
@@ -696,6 +752,7 @@ class GridSearchCV(
         self.scoring = scoring
         self.return_optimized = return_optimized
         self.cv = cv
+        self.train_dataset_transform = train_dataset_transform
         self.pure_parameters = pure_parameters
         self.return_train_score = return_train_score
         self.verbose = verbose
@@ -819,6 +876,7 @@ class GridSearchCV(
             # We clone twice, in case one of the params was itself an algorithm.
             best_optimizer = Optimize(
                 self.pipeline.clone().set_params(**self.best_params_).clone(),
+                train_dataset_transform=self.train_dataset_transform,
                 safe_optimize=self.safe_optimize,
             )
             final_optimize_start_time = time.time()
@@ -833,6 +891,7 @@ class GridSearchCV(
         # In the future we might be able to allow objects with optimizer Interface as input directly.
         optimizer = Optimize(
             self.pipeline,
+            train_dataset_transform=self.train_dataset_transform,
             safe_optimize=self.safe_optimize,
             optimize_with_info=self.optimize_with_info,
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -65,6 +65,24 @@ def _create_random_bool_map(n, seed):
 
 
 class TestDataset:
+    def test_grouping_materialized_during_index_creation_applies_immediately(self):
+        class LazyGroupedDataset(Dataset):
+            def create_index(self) -> pd.DataFrame:
+                self.groupby_cols = "patient"
+                return pd.DataFrame(
+                    {
+                        "patient": ["patient_1", "patient_1", "patient_2"],
+                        "recording": ["recording_1", "recording_2", "recording_1"],
+                    }
+                )
+
+        dataset = LazyGroupedDataset()
+
+        assert dataset.groupby_cols is None
+        assert len(dataset) == 2
+        assert dataset.groupby_cols == "patient"
+        assert len(dataset) == 2
+
     @pytest.mark.parametrize(
         ("groupby", "length"),
         [

--- a/tests/test_dataset_wrapper.py
+++ b/tests/test_dataset_wrapper.py
@@ -1,0 +1,124 @@
+from typing import Generic, NamedTuple, Optional, TypeVar, Union
+
+import pandas as pd
+import pytest
+
+from tpcp import Dataset, DatasetWrapperMixin
+
+
+class DomainDataset(Dataset):
+    def create_index(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "patient": ["patient_1", "patient_1", "patient_2"],
+                "recording": ["recording_1", "recording_2", "recording_1"],
+            }
+        )
+
+    @property
+    def recordings(self) -> tuple[str, ...]:
+        self.assert_is_single_group("recordings")
+        return tuple(self.index["recording"])
+
+
+class VariantDataset(DatasetWrapperMixin[DomainDataset], DomainDataset):
+    _wrapper_groupby_cols = ("variant",)
+
+    def __init__(
+        self,
+        wrapped_dataset: DomainDataset,
+        variants: tuple[int, ...] = (0, 1),
+        *,
+        groupby_cols: Optional[Union[list[str], str]] = None,
+        subset_index: Optional[pd.DataFrame] = None,
+    ) -> None:
+        self.wrapped_dataset = wrapped_dataset
+        self.variants = variants
+        super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
+
+    def _create_wrapped_index(self, source_index: pd.DataFrame) -> pd.DataFrame:
+        return pd.concat(
+            [source_index.assign(variant=variant) for variant in self.variants],
+            ignore_index=True,
+        )
+
+    @property
+    def recordings(self) -> tuple[str, ...]:
+        return self.wrapped_datapoint.recordings
+
+
+GroupLabelT = TypeVar("GroupLabelT", bound=tuple[str, ...])
+
+
+class GenericDomainDataset(Dataset[GroupLabelT], Generic[GroupLabelT]):
+    pass
+
+
+class SourceGroupLabel(NamedTuple):
+    patient: str
+    recording: str
+
+
+class VariantGroupLabel(NamedTuple):
+    patient: str
+    recording: str
+    variant: str
+
+
+class NamedSourceDataset(GenericDomainDataset[SourceGroupLabel]):
+    def create_index(self) -> pd.DataFrame:
+        return pd.DataFrame({"patient": ["patient_1"], "recording": ["recording_1"]})
+
+
+class NamedVariantDataset(
+    DatasetWrapperMixin[NamedSourceDataset],
+    GenericDomainDataset[VariantGroupLabel],
+):
+    _wrapper_groupby_cols = ("variant",)
+
+    def __init__(
+        self,
+        wrapped_dataset: NamedSourceDataset,
+        *,
+        groupby_cols: Optional[Union[list[str], str]] = None,
+        subset_index: Optional[pd.DataFrame] = None,
+    ) -> None:
+        self.wrapped_dataset = wrapped_dataset
+        super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
+
+    def _create_wrapped_index(self, source_index: pd.DataFrame) -> pd.DataFrame:
+        return source_index.assign(variant="0")
+
+
+class TestDatasetWrapperMixin:
+    def test_links_grouping_and_resolves_wrapped_datapoint(self):
+        source = DomainDataset(groupby_cols="patient")
+        wrapped = VariantDataset(source)
+
+        assert isinstance(wrapped, DomainDataset)
+        assert wrapped.groupby_cols is None
+        assert len(wrapped) == 4
+        assert wrapped.groupby_cols == ["patient", "variant"]
+        assert wrapped[0].recordings == ("recording_1", "recording_2")
+        assert wrapped[0].wrapped_datapoint.groupby_cols == ["patient"]
+
+    def test_mixin_must_precede_dataset_base(self):
+        with pytest.raises(TypeError, match="DatasetWrapperMixin.*before.*Dataset"):
+
+            class InvalidWrapper(DomainDataset, DatasetWrapperMixin[DomainDataset]):
+                pass
+
+    def test_resolves_wrapped_subset_when_grouped_only_by_wrapper_column(self):
+        source = DomainDataset()
+        wrapped_variant = VariantDataset(source).groupby("variant")[0]
+
+        wrapped_subset = wrapped_variant.wrapped_datapoint
+
+        assert wrapped_subset.groupby_cols is None
+        pd.testing.assert_frame_equal(wrapped_subset.index, source.index)
+
+    def test_wrapper_and_source_retain_their_named_group_label_types(self):
+        wrapped = NamedVariantDataset(NamedSourceDataset())
+
+        assert isinstance(wrapped.index_as_tuples()[0], VariantGroupLabel)
+        assert isinstance(wrapped[0].wrapped_datapoint.index_as_tuples()[0], SourceGroupLabel)

--- a/tests/test_examples/test_all_examples.py
+++ b/tests/test_examples/test_all_examples.py
@@ -95,7 +95,7 @@ def test_train_dataset_transform():
 
     assert isinstance(raw_dataset, ImageDataset)
     assert isinstance(augmented_dataset, AugmentedImageDataset)
-    assert augmented_dataset.original_dataset is raw_dataset
+    assert augmented_dataset.wrapped_dataset is not raw_dataset
     assert_array_equal(raw_dataset[0].image, [[1, 0, 0], [1, 1, 0], [1, 0, 0]])
     rotated_datapoint = augmented_dataset.get_subset(sample_id=0, rotation_deg=90)
     assert rotated_datapoint.label == raw_dataset[0].label
@@ -106,8 +106,8 @@ def test_train_dataset_transform():
 
     grouped_dataset = raw_dataset.groupby("sample_id")
     grouped_augmented_dataset = rotate_training_images(grouped_dataset)
-    assert grouped_augmented_dataset.groupby_cols == ["sample_id", "rotation_deg"]
     assert len(grouped_augmented_dataset) == 24
+    assert grouped_augmented_dataset.groupby_cols == ["sample_id", "rotation_deg"]
     assert grouped_augmented_dataset[0].label == grouped_dataset[0].label
     assert_array_equal(grouped_augmented_dataset[0].image, grouped_dataset[0].image)
 

--- a/tests/test_examples/test_all_examples.py
+++ b/tests/test_examples/test_all_examples.py
@@ -80,6 +80,43 @@ def test_advanced_cross_validate(snapshot):
     )
 
 
+def test_train_dataset_transform():
+    from examples.validation._05_train_dataset_transform import (
+        AugmentedImageDataset,
+        ImageDataset,
+        augmentation_results,
+        augmentation_training_sizes,
+        augmented_dataset,
+        raw_dataset,
+        rotate_training_images,
+        smoke_test_results,
+        smoke_test_training_sizes,
+    )
+
+    assert isinstance(raw_dataset, ImageDataset)
+    assert isinstance(augmented_dataset, AugmentedImageDataset)
+    assert augmented_dataset.original_dataset is raw_dataset
+    assert_array_equal(raw_dataset[0].image, [[1, 0, 0], [1, 1, 0], [1, 0, 0]])
+    rotated_datapoint = augmented_dataset.get_subset(sample_id=0, rotation_deg=90)
+    assert rotated_datapoint.label == raw_dataset[0].label
+    assert_array_equal(
+        rotated_datapoint.image,
+        [[0, 0, 0], [0, 1, 0], [1, 1, 1]],
+    )
+
+    grouped_dataset = raw_dataset.groupby("sample_id")
+    grouped_augmented_dataset = rotate_training_images(grouped_dataset)
+    assert grouped_augmented_dataset.groupby_cols == ["sample_id", "rotation_deg"]
+    assert len(grouped_augmented_dataset) == 24
+    assert grouped_augmented_dataset[0].label == grouped_dataset[0].label
+    assert_array_equal(grouped_augmented_dataset[0].image, grouped_dataset[0].image)
+
+    assert augmentation_training_sizes == [16, 16, 16]
+    assert smoke_test_training_sizes == [2, 2, 2]
+    assert all(len(labels) == 2 for labels in augmentation_results["test__data_labels"])
+    assert all(len(labels) == 2 for labels in smoke_test_results["test__data_labels"])
+
+
 def test_optuna():
     from examples.parameter_optimization._04_custom_optuna_optimizer import opti, opti_early_stop
 

--- a/tests/test_pipelines/test_optimize.py
+++ b/tests/test_pipelines/test_optimize.py
@@ -578,6 +578,32 @@ class TestGridSearchCV:
         # Final optimize was called with all the data.
         assert len(mock.call_args_list[-1][0][1]) == 5
 
+    def test_train_dataset_transform_is_applied_after_each_split_and_for_final_optimization(self):
+        optimized_pipe = DummyOptimizablePipeline(optimized=True)
+        dataset = DummyDataset()
+
+        def subsample_for_smoke_test(train_dataset):
+            return train_dataset[:1]
+
+        with patch.object(DummyOptimizablePipeline, "self_optimize", return_value=optimized_pipe) as mock:
+            mock.__name__ = "self_optimize"
+            result = GridSearchCV(
+                DummyOptimizablePipeline(),
+                ParameterGrid({"para_1": [1, 2]}),
+                scoring=dummy_single_score_func,
+                cv=2,
+                return_optimized=True,
+                return_train_score=True,
+                train_dataset_transform=subsample_for_smoke_test,
+                safe_optimize=False,
+            ).optimize(dataset)
+
+        # Two candidates in two folds, followed by optimization of the best candidate on all data.
+        assert [len(call.args[0]) for call in mock.call_args_list] == [1, 1, 1, 1, 1]
+        assert all(len(labels) == 2 for labels in result.cv_results_["split0__train__data_labels"])
+        assert all(len(labels) == 3 for labels in result.cv_results_["split1__train__data_labels"])
+        assert len(dataset) == 5
+
     @pytest.mark.parametrize(("pure_paras", "call_count"), [(False, 6 * 2), (True, 2 * 2), (["para_1"], 2 * 2)])
     def test_pure_parameters(self, pure_paras, call_count):
         optimized_pipe = DummyOptimizablePipeline()
@@ -732,6 +758,28 @@ class TestOptimize:
         assert result.optimized_pipeline_.get_params() == optimized_pipe.get_params()
         # The id must been different, indicating that `optimize` correctly called clone on the output
         assert id(result.optimized_pipeline_) != id(optimized_pipe)
+
+    def test_train_dataset_transform_changes_only_the_dataset_used_for_optimization(self):
+        optimized_pipe = DummyOptimizablePipeline(optimized=True)
+        dataset = DummyDataset()
+
+        def subsample_for_smoke_test(train_dataset):
+            return train_dataset.set_params(subset_index=train_dataset.index.iloc[:2].reset_index(drop=True))
+
+        with patch.object(DummyOptimizablePipeline, "self_optimize", return_value=optimized_pipe) as mock:
+            mock.__name__ = "self_optimize"
+            result = Optimize(
+                DummyOptimizablePipeline(),
+                train_dataset_transform=subsample_for_smoke_test,
+                safe_optimize=False,
+            ).optimize(dataset)
+
+        transformed_dataset = mock.call_args.args[0]
+        assert len(transformed_dataset) == 2
+        assert len(dataset) == 5
+        assert result.dataset is dataset
+        assert result.transformed_dataset_ is transformed_dataset
+        assert transformed_dataset is not dataset
 
     def test_mutable_inputs(self):
         """Test how mutable inputs are handled.


### PR DESCRIPTION
## Summary

- establish a repository policy requiring backwards-compatible public interface changes by default
- configure RoboRev with only the repository-specific compatibility guideline, leaving unrelated settings inherited
- add an optional `train_dataset_transform` callable to `Optimize` and `GridSearchCV`
- apply transforms only to cloned training datasets after each cross-validation split and during final refitting
- preserve the original train/test dataset interface and leave validation datasets untouched
- add the public `DatasetWrapperMixin` for lazy dataset wrappers that retain a shared domain dataset interface
- document and enforce that `DatasetWrapperMixin` must precede the domain dataset base in the inheritance list
- demonstrate real image-rotation augmentation and smoke-test subsampling
- materialize lazy dataset indices before resolving grouping, allowing wrappers to establish grouping while creating their index

## Motivation

TPCP currently splits a complete dataset into cross-validation folds, but has no fold-local primitive for augmenting,
multiplying, or subsampling training datapoints before pipeline optimization. This makes common training-only operations
difficult without leaking transformed data into validation folds.

The new callable provides a deliberately small dataset-in/dataset-out seam. Raw and transformed datasets can be
different concrete subclasses as long as they implement the same domain-specific dataset interface expected by the
pipeline.

`DatasetWrapperMixin` captures the common mechanics for this pattern: it expands a copy of the wrapped index, derives
the wrapper's initial grouping from the wrapped dataset, and resolves the source datapoint represented by an augmented
datapoint. The rotation example therefore only defines the extra index dimension and proxies its domain properties.

The required declaration is:

```python
class AugmentedImageDataset(DatasetWrapperMixin[ImageDataset], ImageDataset):
    ...
```

The mixin must be first because Python's method resolution order needs to select its `create_index` implementation.
This requirement is prominent in the mixin API docs, dataset module docs, dataset/pipeline guide, and rotation example;
reversed inheritance is also rejected with a targeted `TypeError`.

Dataset grouping now resolves only after lazy index materialization. This lets wrapper datasets derive their initial
grouping while creating their expanded index, without producing a different result on the first grouping-dependent
operation.

## Backwards compatibility

This is an additive change. The new transform parameter defaults to `None`, preserving existing behavior. When
supplied, the transform receives a clone so an in-place implementation cannot mutate the optimizer input dataset.

Existing datasets retain their grouping behavior; the materialization-order change only makes grouping assigned during
`create_index()` effective immediately. The wrapper mixin is a new opt-in public API.

No breaking public-interface changes are included.

## Verification

- `uv run --no-sync poe ci_check`
- `uv run --no-sync pyright examples/validation/_05_train_dataset_transform.py tests/test_dataset_wrapper.py` — 0 errors
- `uv run --no-sync poe test` — 543 passed, 13 skipped
- `uv build`
- Sphinx API-doc render with examples disabled — passed (existing documentation warnings only)
- `git diff --check` over the full stack
- RoboRev per-commit and final whole-stack reviews — all findings resolved; no open jobs
