### PR TITLE
Propagate runtime context through parallel workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,17 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registration functions reject names using this prefix. Existing user registrations with this prefix must be
   renamed.
   (https://github.com/mad-lab-fau/tpcp/pull/138)
+- All parallel execution inside TPCP now uses the context-aware `tpcp.parallel.Parallel`. Python warning filters,
+  warning/error contexts, and global cache setup are restored automatically in workers; successful side-channel data
+  is recovered in the parent process.
+  (https://github.com/mad-lab-fau/tpcp/pull/138)
 - `Scorer` now adds structured iteration context to warnings and errors raised by custom score aggregators and
   single-score callbacks.
   (https://github.com/mad-lab-fau/tpcp/pull/138)
-- **Breaking:** Error and warning text from `validate`, `cross_validate`, `GridSearch`, `GridSearchCV`, `Scorer`,
-  `TypedIterator`, and Optuna optimization now includes structured context metadata instead of the previous ad-hoc
-  error strings.
+- **Breaking:** Warnings and errors from `validate`, `cross_validate`, `GridSearch`, `GridSearchCV`, `Scorer`,
+  `TypedIterator`, and Optuna optimization now use contextualized warning text and exception notes instead of the
+  previous ad-hoc error strings.
   Code or tests that match exact warning or exception messages need to be updated.
-  (https://github.com/mad-lab-fau/tpcp/pull/131)
-- **Breaking:** The private `_score` and `_optimize_and_score` helpers no longer accept `error_info`; callers must pass
-  structured context entries instead.
-  (https://github.com/mad-lab-fau/tpcp/pull/131)
+  (https://github.com/mad-lab-fau/tpcp/pull/131, https://github.com/mad-lab-fau/tpcp/pull/138)
+- **Breaking:** The private `_score` and `_optimize_and_score` helpers no longer accept `error_info` or `context`.
+  Callers that need diagnostic context must activate `warning_error_context` while constructing the delayed task.
+  (https://github.com/mad-lab-fau/tpcp/pull/131, https://github.com/mad-lab-fau/tpcp/pull/138)
 
 ## [2.2.1] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `tpcp.parallel.Parallel` and public parallel side-channel registration. Together with
+  `tpcp.parallel.delayed`, this restores per-task state and returns side-channel data from successful workers
+  without changing task return values.
+  (https://github.com/mad-lab-fau/tpcp/pull/138)
 - Added an optional `train_dataset_transform` callable to `Optimize` and `GridSearchCV` for fold-local training-data
   augmentation and subsampling.
   (https://github.com/mad-lab-fau/tpcp/pull/137)
@@ -28,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Names beginning with `__tpcp_internal__.` are now reserved for TPCP parallel callbacks and side
+  channels. `register_global_parallel_callback`, `remove_global_parallel_callback`, and the new side-channel
+  registration functions reject names using this prefix. Existing user registrations with this prefix must be
+  renamed.
+  (https://github.com/mad-lab-fau/tpcp/pull/138)
 - `Scorer` now adds structured iteration context to warnings and errors raised by custom score aggregators and
   single-score callbacks.
   (https://github.com/mad-lab-fau/tpcp/pull/138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Scorer` now adds structured iteration context to warnings and errors raised by custom score aggregators and
+  single-score callbacks.
+  (https://github.com/mad-lab-fau/tpcp/pull/138)
 - **Breaking:** Error and warning text from `validate`, `cross_validate`, `GridSearch`, `GridSearchCV`, `Scorer`,
   `TypedIterator`, and Optuna optimization now includes structured context metadata instead of the previous ad-hoc
   error strings.

--- a/docs/guides/multiprocessing_caveats.rst
+++ b/docs/guides/multiprocessing_caveats.rst
@@ -47,10 +47,9 @@ tpcp workaround: ``tpcp.parallel``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `tpcp` provides :mod:`tpcp.parallel` as a workaround for this class of problem.
-Its :func:`~tpcp.parallel.delayed` wrapper captures registered state, Python warning filters, and active
-:func:`~tpcp.misc.warning_error_context` instances in the parent process and restores them for each worker task.
-Its :class:`~tpcp.parallel.Parallel` subclass can additionally return contextual warning and print records to the
-original parent context without exposing an internal wrapper around task results.
+Its :func:`~tpcp.parallel.delayed` wrapper captures registered state in the parent process and restores it for each
+worker task. Its :class:`~tpcp.parallel.Parallel` subclass can additionally return side-channel data to the parent
+without exposing an internal wrapper around task results.
 
 The workflow is:
 
@@ -143,7 +142,7 @@ Related background:
     :func:`tpcp.parallel.delayed` remains compatible with :class:`joblib.Parallel`, which restores worker state but
     does not recover side-channel data. Pair it with :class:`tpcp.parallel.Parallel` when data from successful worker
     tasks should be merged into parent-process state. A task that raises does not return its side-channel data; its
-    original exception is propagated with any worker-side warning/error context.
+    original exception is propagated with any worker-side annotations.
 
 Custom side channels
 ~~~~~~~~~~~~~~~~~~~~
@@ -164,35 +163,19 @@ The second half of the example collects application-defined worker events withou
 The registration must remain active until all results, including generator results, have been consumed. Names with
 the ``__tpcp_internal__.`` prefix are reserved for built-in TPCP side channels.
 
-Warning and error contexts
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+TPCP-managed features
+~~~~~~~~~~~~~~~~~~~~~
 
-Warning/error contexts need no explicit callback registration. The active context stack and warning filters are
-captured automatically when :func:`tpcp.parallel.delayed` creates a task. Restored contexts are limited to that task,
-so reused joblib workers do not retain context or filters from earlier work.
+TPCP registers the parallel state needed by several built-in features automatically:
 
-A propagated ``context_provider`` is evaluated once when each worker task starts. All events in that task use this
-snapshot. If metadata must change while worker code is running, create a nested context with its own provider inside
-the worker function.
-
-Use :class:`tpcp.parallel.Parallel` to recover records from successful workers:
-
-.. code-block:: python
-
-    import warnings
-
-    from tpcp.misc import warning_error_context
-    from tpcp.parallel import Parallel, delayed
-
-    def worker_func(value):
-        warnings.warn(f"processing {value}", UserWarning, stacklevel=1)
-        return value * 2
-
-    with warning_error_context("program", record_only=True) as context:
-        results = Parallel(n_jobs=2)(delayed(worker_func)(value) for value in range(4))
-
-    assert results == [0, 2, 4, 6]
-    assert len(context.records) == 4
+- **Warning filters:** The active Python warning filters are captured for each delayed task and scoped to that task in
+  process workers, preventing filter changes from leaking through reused processes. Thread workers share
+  process-global filters and use the filters active when each task executes.
+- **Warning/error contexts:** Active :func:`~tpcp.misc.warning_error_context` stacks are restored around each task, and
+  :class:`~tpcp.parallel.Parallel` returns records from successful tasks. A propagated ``context_provider`` is
+  evaluated once when the task starts, so its result is a per-task snapshot.
+- **Global caches:** :func:`~tpcp.caching.global_disk_cache` and :func:`~tpcp.caching.global_ram_cache` register the
+  callbacks required to recreate their cache setup in workers when ``restore_in_parallel_process=True``.
 
 .. warning::
     Different libraries may implement their own worker-state restoration logic.

--- a/docs/guides/multiprocessing_caveats.rst
+++ b/docs/guides/multiprocessing_caveats.rst
@@ -47,7 +47,10 @@ tpcp workaround: ``tpcp.parallel``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `tpcp` provides :mod:`tpcp.parallel` as a workaround for this class of problem.
-Its :func:`~tpcp.parallel.delayed` wrapper captures registered state in the parent process and restores it in workers.
+Its :func:`~tpcp.parallel.delayed` wrapper captures registered state, Python warning filters, and active
+:func:`~tpcp.misc.warning_error_context` instances in the parent process and restores them for each worker task.
+Its :class:`~tpcp.parallel.Parallel` subclass can additionally return contextual warning and print records to the
+original parent context without exposing an internal wrapper around task results.
 
 The workflow is:
 
@@ -136,6 +139,12 @@ Related background:
     The workaround is only applied when `tpcp.parallel.delayed` is used.
     If your own code uses `joblib.delayed` directly, registered callbacks will not run.
 
+.. note::
+    :func:`tpcp.parallel.delayed` remains compatible with :class:`joblib.Parallel`, which restores worker state but
+    does not recover side-channel data. Pair it with :class:`tpcp.parallel.Parallel` when data from successful worker
+    tasks should be merged into parent-process state. A task that raises does not return its side-channel data; its
+    original exception is propagated with any worker-side warning/error context.
+
 Custom side channels
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -154,6 +163,36 @@ A side channel has three operations:
 The second half of the example collects application-defined worker events without adding them to each task result.
 The registration must remain active until all results, including generator results, have been consumed. Names with
 the ``__tpcp_internal__.`` prefix are reserved for built-in TPCP side channels.
+
+Warning and error contexts
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Warning/error contexts need no explicit callback registration. The active context stack and warning filters are
+captured automatically when :func:`tpcp.parallel.delayed` creates a task. Restored contexts are limited to that task,
+so reused joblib workers do not retain context or filters from earlier work.
+
+A propagated ``context_provider`` is evaluated once when each worker task starts. All events in that task use this
+snapshot. If metadata must change while worker code is running, create a nested context with its own provider inside
+the worker function.
+
+Use :class:`tpcp.parallel.Parallel` to recover records from successful workers:
+
+.. code-block:: python
+
+    import warnings
+
+    from tpcp.misc import warning_error_context
+    from tpcp.parallel import Parallel, delayed
+
+    def worker_func(value):
+        warnings.warn(f"processing {value}", UserWarning, stacklevel=1)
+        return value * 2
+
+    with warning_error_context("program", record_only=True) as context:
+        results = Parallel(n_jobs=2)(delayed(worker_func)(value) for value in range(4))
+
+    assert results == [0, 2, 4, 6]
+    assert len(context.records) == 4
 
 .. warning::
     Different libraries may implement their own worker-state restoration logic.
@@ -298,6 +337,7 @@ tpcp-specific takeaways
 - If global configuration is missing in workers, use :mod:`tpcp.parallel`.
 - If you use custom parallel code together with `tpcp` worker-state restoration, make sure you use
   :func:`~tpcp.parallel.delayed`, not `joblib.delayed`.
+- Use :class:`~tpcp.parallel.Parallel` as well when successful worker tasks should return contextual records.
 - If tests depend on clean workers, explicitly shut down the reusable `loky` executor.
 - If a pickle error mentions `__main__`, move the relevant object to a normal module first.
 - If runtime-created objects are difficult to serialize, pass configuration into workers and build the object there.
@@ -307,6 +347,7 @@ Related APIs
 ------------
 
 - :mod:`tpcp.parallel`
+- :class:`tpcp.parallel.Parallel`
 - :func:`tpcp.parallel.delayed`
 - :func:`tpcp.parallel.register_global_parallel_callback`
 - :func:`tpcp.parallel.register_parallel_side_channel`

--- a/docs/guides/multiprocessing_caveats.rst
+++ b/docs/guides/multiprocessing_caveats.rst
@@ -62,9 +62,17 @@ Example:
 
 .. code-block:: python
 
-    from joblib import Parallel
+    from contextlib import contextmanager
+
     from sklearn import get_config, set_config
-    from tpcp.parallel import delayed, register_global_parallel_callback, remove_global_parallel_callback
+    from tpcp.parallel import (
+        Parallel,
+        delayed,
+        register_global_parallel_callback,
+        register_parallel_side_channel,
+        remove_global_parallel_callback,
+        remove_parallel_side_channel,
+    )
 
     def callback():
         def setter(config):
@@ -72,11 +80,52 @@ Example:
 
         return get_config(), setter
 
-    name = register_global_parallel_callback(callback)
+    def read_config():
+        return get_config()["assume_finite"]
+
+    set_config(assume_finite=True)
+    callback_name = register_global_parallel_callback(callback)
     try:
-        Parallel(n_jobs=2)(delayed(worker_func)() for _ in range(2))
+        worker_configs = Parallel(n_jobs=2)(delayed(read_config)() for _ in range(2))
     finally:
-        remove_global_parallel_callback(name)
+        remove_global_parallel_callback(callback_name)
+
+    assert worker_configs == [True, True]
+
+    # A side channel can additionally return data from successful worker tasks.
+    worker_events = []
+    collected_events = []
+
+    @contextmanager
+    def restore_events(run_name):
+        global worker_events
+        worker_events = []
+        try:
+            yield lambda: tuple((run_name, event) for event in worker_events)
+        finally:
+            worker_events = []
+
+    def worker_func(value):
+        worker_events.append(f"processed {value}")
+        return value * 2
+
+    side_channel_name = register_parallel_side_channel(
+        lambda: "experiment-1",
+        restore_events,
+        collected_events.extend,
+    )
+    try:
+        results = Parallel(n_jobs=2)(delayed(worker_func)(value) for value in range(4))
+    finally:
+        remove_parallel_side_channel(side_channel_name)
+
+    assert results == [0, 2, 4, 6]
+    assert collected_events == [
+        ("experiment-1", "processed 0"),
+        ("experiment-1", "processed 1"),
+        ("experiment-1", "processed 2"),
+        ("experiment-1", "processed 3"),
+    ]
 
 Related background:
 
@@ -86,6 +135,25 @@ Related background:
 .. note::
     The workaround is only applied when `tpcp.parallel.delayed` is used.
     If your own code uses `joblib.delayed` directly, registered callbacks will not run.
+
+Custom side channels
+~~~~~~~~~~~~~~~~~~~~
+
+:func:`~tpcp.parallel.register_global_parallel_callback` is sufficient for state that only travels from the parent
+to a worker. For state that should also return from successful worker tasks, register a side channel with
+:func:`~tpcp.parallel.register_parallel_side_channel`.
+
+A side channel has three operations:
+
+1. ``capture`` snapshots state when :func:`~tpcp.parallel.delayed` creates a task. Returning ``None`` disables the
+   side channel for that task.
+2. ``restore`` creates a context manager around that worker task. The context manager yields a callable that collects
+   the worker-side data after the task succeeds.
+3. ``merge`` receives the collected data in the parent as :class:`~tpcp.parallel.Parallel` consumes each result.
+
+The second half of the example collects application-defined worker events without adding them to each task result.
+The registration must remain active until all results, including generator results, have been consumed. Names with
+the ``__tpcp_internal__.`` prefix are reserved for built-in TPCP side channels.
 
 .. warning::
     Different libraries may implement their own worker-state restoration logic.
@@ -241,4 +309,6 @@ Related APIs
 - :mod:`tpcp.parallel`
 - :func:`tpcp.parallel.delayed`
 - :func:`tpcp.parallel.register_global_parallel_callback`
+- :func:`tpcp.parallel.register_parallel_side_channel`
 - :func:`tpcp.parallel.remove_global_parallel_callback`
+- :func:`tpcp.parallel.remove_parallel_side_channel`

--- a/docs/modules/parallel.rst
+++ b/docs/modules/parallel.rst
@@ -19,4 +19,6 @@ Functions
 
     delayed
     register_global_parallel_callback
+    register_parallel_side_channel
     remove_global_parallel_callback
+    remove_parallel_side_channel

--- a/docs/modules/parallel.rst
+++ b/docs/modules/parallel.rst
@@ -1,5 +1,5 @@
-tpcp.parallel: Helper for global settings during parallel execution
-===================================================================
+tpcp.parallel: Context-aware parallel execution
+================================================
 
 For practical caveats around joblib-based multiprocessing, worker state, serialization, and import costs, see
 :ref:`multiprocessing_caveats`.
@@ -22,3 +22,12 @@ Functions
     register_parallel_side_channel
     remove_global_parallel_callback
     remove_parallel_side_channel
+
+Classes
+-------
+
+.. autosummary::
+    :toctree: generated/parallel
+    :template: class.rst
+
+    Parallel

--- a/examples/recipies/_01_caching.py
+++ b/examples/recipies/_01_caching.py
@@ -220,7 +220,8 @@ cache.clear()
 #    of multiprocessing.
 #    Make sure to double-check that everything works as expected.
 #    If not, you might be able to use :func:`~tpcp.parallel.register_global_parallel_callback` to fix the issue.
-#    (at least in the context of joblib based multiprocessing).
+#    Use :func:`~tpcp.parallel.delayed` for custom joblib tasks and pair it with
+#    :class:`~tpcp.parallel.Parallel` when warning-context records should be recovered from successful workers.
 #
 # Below we demonstrate how to apply the decorator to a class after the fact.
 from tpcp.caching import global_disk_cache, remove_any_cache

--- a/examples/recipies/_07_warning_error_context.py
+++ b/examples/recipies/_07_warning_error_context.py
@@ -10,8 +10,8 @@ optimization trial, or iteration triggered it.
 
 This example covers fixed and dynamic context, nested contexts, retained event
 records, contextual prints, manual lifecycle control, quiet record-only
-execution, arbitrary iterators, :class:`~tpcp.misc.TypedIterator`, and typed
-sub-iterations.
+execution, restoration in parallel workers, arbitrary iterators,
+:class:`~tpcp.misc.TypedIterator`, and typed sub-iterations.
 
 Simple and dynamic context
 --------------------------
@@ -31,6 +31,7 @@ from tpcp.misc import (
     print_with_context,
     warning_error_context,
 )
+from tpcp.parallel import Parallel, delayed
 
 with warning_error_context("record", {"participant": "p1"}):
     warnings.warn("signal is short", UserWarning, stacklevel=1)
@@ -169,6 +170,50 @@ with warnings.catch_warnings():
                 print_with_context("Processed", item)
 
 print([record.type for record in program_context.records])
+
+
+# %%
+# Parallel workers
+# ----------------
+# :func:`tpcp.parallel.delayed` captures the active context when a task is
+# created and restores it around that task in a process worker. Contexts opened
+# inside the worker stack on top of the restored context. Pairing ``delayed``
+# with :class:`tpcp.parallel.Parallel` also merges warning and contextual-print
+# records from successful tasks back into the original parent context.
+#
+# Both TPCP helpers are required for this complete round trip:
+# :func:`tpcp.parallel.delayed` restores the context in the worker, while
+# :class:`tpcp.parallel.Parallel` recovers its records in the parent. The
+# corresponding :mod:`joblib` helpers do not provide both parts automatically.
+def run_parallel_example():
+    """Run the example without making the worker import this gallery module."""
+
+    def process_in_worker(item: str) -> str:
+        with warning_error_context("worker", {"item": item}):
+            warnings.warn("worker warning", UserWarning, stacklevel=1)
+            print_with_context("Worker processed", item)
+        return item.upper()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        with warning_error_context(
+            "parent", {"run": "validation"}, record_only=True
+        ) as parallel_context:
+            parallel_results = Parallel(n_jobs=2)(
+                delayed(process_in_worker)(item) for item in ["left", "right"]
+            )
+    return parallel_results, parallel_context.records
+
+
+parallel_results, parallel_records = run_parallel_example()
+
+print(parallel_results)
+print(
+    [
+        (record.type, record.context, str(record.message))
+        for record in parallel_records
+    ]
+)
 
 # %%
 # Arbitrary iterators

--- a/src/tpcp/_utils/_score.py
+++ b/src/tpcp/_utils/_score.py
@@ -8,7 +8,6 @@ The original code is licenced under BSD-3: https://github.com/scikit-learn/sciki
 from __future__ import annotations
 
 import time
-from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from joblib import Memory
@@ -18,11 +17,9 @@ from tpcp._base import clone
 from tpcp._hash import custom_hash
 from tpcp._utils._general import _get_nested_paras
 from tpcp.exceptions import OptimizationError, TestError
-from tpcp.misc._warning_error_context import _render_contexts, warning_error_context
+from tpcp.misc import warning_error_context
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from tpcp._dataset import Dataset
     from tpcp._optimize import BaseOptimize
     from tpcp._pipeline import Pipeline
@@ -58,22 +55,6 @@ class _OptimizeScoreResults(TypedDict, total=False):
     optimizer: BaseOptimize
 
 
-def _contextualize(context: Optional[Sequence[tuple[str, dict[str, Any]]]]) -> ExitStack:
-    stack = ExitStack()
-    for name, metadata in context or ():
-        stack.enter_context(warning_error_context(name, metadata))
-    return stack
-
-
-def _contextualized_error_message(
-    message: str,
-    context: Optional[Sequence[tuple[str, dict[str, Any]]]],
-    phase: str,
-    **phase_metadata: Any,
-) -> str:
-    return f"{message}\nContext: {_render_contexts([*(context or ()), (phase, phase_metadata)])}"
-
-
 def _score(
     pipeline: Pipeline,
     dataset: Dataset,
@@ -82,7 +63,6 @@ def _score(
     return_parameters=False,
     return_data_labels=False,
     return_times=False,
-    context: Optional[Sequence[tuple[str, dict[str, Any]]]] = None,
 ) -> _ScoreResults:
     """Set parameters and return score.
 
@@ -118,22 +98,21 @@ def _score(
             The parameters that have been evaluated.
 
     """
-    with _contextualize(context):
-        if parameters is not None:
-            # clone after setting parameters in case any parameters are estimators (like pipeline steps).
-            parameters = _clone_parameter_dict(parameters)
+    if parameters is not None:
+        # clone after setting parameters in case any parameters are estimators (like pipeline steps).
+        parameters = _clone_parameter_dict(parameters)
 
-            pipeline = pipeline.set_params(**parameters)
+        pipeline = pipeline.set_params(**parameters)
 
-        score_context: dict[str, Any] = {}
+    score_context: dict[str, Any] = {}
+    with warning_error_context("score", context_provider=lambda: score_context):
         try:
             start_time = time.time()
             score_context = {"data_labels": dataset.group_labels}
-            with warning_error_context("score", score_context):
-                agg_scores, single_scores = scorer(pipeline, dataset)
+            agg_scores, single_scores = scorer(pipeline, dataset)
             score_time = time.time() - start_time
         except Exception as e:
-            raise TestError(_contextualized_error_message("Testing failed.", context, "score", **score_context)) from e
+            raise TestError("Testing failed.") from e
 
     result: _ScoreResults = {
         "scores": agg_scores,
@@ -163,7 +142,6 @@ def _optimize_and_score(
     return_data_labels=False,
     return_times=False,
     memory: Optional[Memory] = None,
-    context: Optional[Sequence[tuple[str, dict[str, Any]]]] = None,
 ) -> _OptimizeScoreResults:
     """Optimize and score the optimized pipeline on the train and test data, respectively.
 
@@ -190,80 +168,73 @@ def _optimize_and_score(
     Let's better be safe and reduce the surface for bugs even further here.
 
     """
-    with _contextualize(context):
-        if memory is None:
-            memory = Memory(None)
-        # clone after setting parameters in case any parameters are estimators (like pipeline steps).
-        hyperparameters = _clone_parameter_dict(hyperparameters)
-        pure_parameters = _clone_parameter_dict(pure_parameters)
+    if memory is None:
+        memory = Memory(None)
+    # clone after setting parameters in case any parameters are estimators (like pipeline steps).
+    hyperparameters = _clone_parameter_dict(hyperparameters)
+    pure_parameters = _clone_parameter_dict(pure_parameters)
 
-        optimize_params_clean: dict = optimize_params or {}
+    optimize_params_clean: dict = optimize_params or {}
 
-        optimize_context: dict[str, Any] = {}
+    optimize_context: dict[str, Any] = {}
+    with warning_error_context("optimize", context_provider=lambda: optimize_context):
         try:
             start_time = time.time()
             optimize_context = {"data_labels": train_set.group_labels}
-            with warning_error_context("optimize", optimize_context):
-                optimizer = _cached_optimize(
-                    optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
-                )
+            optimizer = _cached_optimize(
+                optimizer, train_set, hyperparameters, pure_parameters, memory, optimize_params_clean
+            )
             optimize_time = time.time() - start_time
         except Exception as e:
-            raise OptimizationError(
-                _contextualized_error_message("Optimization failed.", context, "optimize", **optimize_context)
-            ) from e
+            raise OptimizationError("Optimization failed.") from e
 
-        # Now we set the remaining paras.
-        # Because, we need to set the parameters on the optimized pipeline and not the input pipeline we strip the
-        # naming prefix.
-        striped_paras = _get_nested_paras(pure_parameters, "pipeline")
-        optimizer.optimized_pipeline_.set_params(**striped_paras)
-        # We also set the parameters of the input pipeline to make it seem that all parameters were set from the
-        # beginning.
-        optimizer = optimizer.set_params(**pure_parameters)
+    # Now we set the remaining paras.
+    # Because, we need to set the parameters on the optimized pipeline and not the input pipeline we strip the
+    # naming prefix.
+    striped_paras = _get_nested_paras(pure_parameters, "pipeline")
+    optimizer.optimized_pipeline_.set_params(**striped_paras)
+    # We also set the parameters of the input pipeline to make it seem that all parameters were set from the
+    # beginning.
+    optimizer = optimizer.set_params(**pure_parameters)
 
-        test_score_context: dict[str, Any] = {}
+    test_score_context: dict[str, Any] = {}
+    with warning_error_context("test_score", context_provider=lambda: test_score_context):
         try:
             test_score_context = {"data_labels": test_set.group_labels}
-            with warning_error_context("test_score", test_score_context):
-                agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
+            agg_scores, single_scores = scorer(optimizer.optimized_pipeline_, test_set)
             score_time = time.time() - optimize_time - start_time
         except Exception as e:
-            raise TestError(
-                _contextualized_error_message("Testing failed.", context, "test_score", **test_score_context)
-            ) from e
+            raise TestError("Testing failed.") from e
 
-        result: _OptimizeScoreResults = {
-            "test__scores": agg_scores,
-            "test__single__scores": single_scores,
-        }
-        if return_train_score:
-            train_score_context: dict[str, Any] = {}
+    result: _OptimizeScoreResults = {
+        "test__scores": agg_scores,
+        "test__single__scores": single_scores,
+    }
+    if return_train_score:
+        train_score_context: dict[str, Any] = {}
+        with warning_error_context("train_score", context_provider=lambda: train_score_context):
             try:
                 train_score_context = {"data_labels": train_set.group_labels}
-                with warning_error_context("train_score", train_score_context):
-                    train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
+                train_agg_scores, train_single_scores = scorer(optimizer.optimized_pipeline_, train_set)
             except Exception as e:
-                raise TestError(
-                    _contextualized_error_message("Testing failed.", context, "train_score", **train_score_context)
-                ) from e
-            result["train__scores"] = train_agg_scores
-            result["train__single__scores"] = train_single_scores
-        if return_times:
-            result["debug__score_time"] = score_time
-            result["debug__optimize_time"] = optimize_time
-        if return_data_labels:
-            # Note we always return the train data attribute as it is interesting information independent of the train
-            # score and has 0 runtime impact.
-            result["train__data_labels"] = train_set.group_labels
-            result["test__data_labels"] = test_set.group_labels
-        if return_optimizer:
-            # This is the actual trained optimizer. This means that `optimizer.optimized_pipeline_` contains the actual
-            # instance of the trained pipeline.
-            result["optimizer"] = optimizer
-        if return_parameters:
-            result["parameters"] = {**hyperparameters, **pure_parameters}
-        return result
+                raise TestError("Testing failed.") from e
+        result["train__scores"] = train_agg_scores
+        result["train__single__scores"] = train_single_scores
+    if return_times:
+        result["debug__score_time"] = score_time
+        result["debug__optimize_time"] = optimize_time
+    if return_data_labels:
+        # Note we always return the train data attribute as it is interesting information independent of the train
+        # score and has 0 runtime impact.
+        result["train__data_labels"] = train_set.group_labels
+        result["test__data_labels"] = test_set.group_labels
+    if return_optimizer:
+        # This is the actual trained optimizer. This means that `optimizer.optimized_pipeline_` contains the actual
+        # instance of the trained pipeline.
+        result["optimizer"] = optimizer
+    if return_parameters:
+        result["parameters"] = {**hyperparameters, **pure_parameters}
+    return result
 
 
 def _cached_optimize(

--- a/src/tpcp/caching.py
+++ b/src/tpcp/caching.py
@@ -14,7 +14,7 @@ from joblib import Memory
 
 from tpcp import Algorithm, get_action_methods_names, get_results, make_action_safe
 from tpcp._hash import custom_hash
-from tpcp.parallel import register_global_parallel_callback, remove_global_parallel_callback
+from tpcp.parallel import _register_tpcp_global_parallel_callback, _remove_tpcp_global_parallel_callback
 
 _ALREADY_WARNED = False
 
@@ -130,7 +130,7 @@ def _register_global_parallel_callback(func, name):
     def _callback():
         return None, wrapper
 
-    register_global_parallel_callback(_callback, name=name)
+    _register_tpcp_global_parallel_callback(name, _callback)
 
 
 def global_disk_cache(  # noqa: C901
@@ -313,7 +313,9 @@ def remove_disk_cache(algorithm_object: type[Algorithm]):
         if getattr(action_method, "__wrapped__", None) is not None:
             setattr(algorithm_object, action_name, action_method.__wrapped__)
             with contextlib.suppress(KeyError):
-                remove_global_parallel_callback(f"global_disk_cache__{algorithm_object.__qualname__}__{action_name}")
+                _remove_tpcp_global_parallel_callback(
+                    f"global_disk_cache__{algorithm_object.__qualname__}__{action_name}"
+                )
     return algorithm_object
 
 
@@ -453,7 +455,7 @@ def remove_ram_cache(algorithm_object: type[Algorithm]):
         if getattr(action_method, "__wrapped__", None) is not None:
             setattr(algorithm_object, action_method_name, action_method.__wrapped__)
             with contextlib.suppress(KeyError):
-                remove_global_parallel_callback(
+                _remove_tpcp_global_parallel_callback(
                     f"global_ram_cache__{algorithm_object.__qualname__}__{action_method_name}"
                 )
 

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from contextvars import ContextVar, Token
 from copy import copy
 from dataclasses import dataclass
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypeVar, Union
+
+from tpcp.parallel import _register_parallel_context
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -151,6 +153,28 @@ def _safe_exception_description(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {message}"
 
 
+def _render_context_with_provider(
+    context: dict[str, Any], context_provider: Optional[Callable[[], Mapping[str, Any]]]
+) -> str:
+    if context_provider is not None:
+        try:
+            provided_context = context_provider()
+            if not isinstance(provided_context, Mapping):
+                raise TypeError("context_provider must return a mapping")
+            duplicate_keys = context.keys() & provided_context.keys()
+            if duplicate_keys:
+                duplicates = ", ".join(sorted(duplicate_keys))
+                raise ValueError(f"context_provider returned duplicate keys: {duplicates}")
+            context = {**context, **provided_context}
+        except BaseException as exc:  # noqa: BLE001 - context rendering must not mask the original event
+            provider_error = _safe_exception_description(exc)
+            rendered_context = _render_context_values(context)
+            rendered_error = f"context_provider_error={provider_error!r}"
+            return ", ".join(filter(None, (rendered_context, rendered_error)))
+
+    return _render_context_values(context)
+
+
 @dataclass(frozen=True)
 class _ContextFrame:
     name: str
@@ -160,27 +184,22 @@ class _ContextFrame:
     record_only: bool = False
 
     def _render_context(self) -> str:
-        context = self.context
-        if self.context_provider is not None:
-            try:
-                provided_context = self.context_provider()
-                if not isinstance(provided_context, Mapping):
-                    raise TypeError("context_provider must return a mapping")
-                duplicate_keys = context.keys() & provided_context.keys()
-                if duplicate_keys:
-                    duplicates = ", ".join(sorted(duplicate_keys))
-                    raise ValueError(f"context_provider returned duplicate keys: {duplicates}")
-                context = {**context, **provided_context}
-            except BaseException as exc:  # noqa: BLE001 - context rendering must not mask the original event
-                provider_error = _safe_exception_description(exc)
-                rendered_context = _render_context_values(context)
-                rendered_error = f"context_provider_error={provider_error!r}"
-                return ", ".join(filter(None, (rendered_context, rendered_error)))
-
-        return _render_context_values(context)
+        return _render_context_with_provider(self.context, self.context_provider)
 
     def render(self) -> str:
         rendered_context = self._render_context()
+        return self.name if not rendered_context else f"{self.name}: {rendered_context}"
+
+
+@dataclass(frozen=True)
+class _ParallelContextFrame:
+    name: str
+    context: dict[str, Any]
+    context_provider: Optional[Callable[[], Mapping[str, Any]]]
+    record_only: bool
+
+    def render(self) -> str:
+        rendered_context = _render_context_with_provider(self.context, self.context_provider)
         return self.name if not rendered_context else f"{self.name}: {rendered_context}"
 
 
@@ -190,6 +209,29 @@ _recorded_error: ContextVar[Optional[BaseException]] = ContextVar("tpcp_warning_
 
 def _render_context_stack() -> str:
     return " > ".join(frame.render() for frame in _context_stack.get())
+
+
+def _capture_parallel_context() -> Optional[tuple[_ParallelContextFrame, ...]]:
+    stack = _context_stack.get()
+    if not stack:
+        return None
+    return tuple(
+        _ParallelContextFrame(
+            name=frame.name,
+            context=dict(frame.context),
+            context_provider=frame.context_provider,
+            record_only=frame.record_only,
+        )
+        for frame in stack
+    )
+
+
+@contextmanager
+def _restore_parallel_context(context: tuple[_ParallelContextFrame, ...]) -> Iterator[None]:
+    with ExitStack() as stack:
+        for frame in context:
+            stack.enter_context(warning_error_context(frame.render(), record_only=frame.record_only))
+        yield
 
 
 def _record_event(
@@ -348,6 +390,13 @@ def warning_error_context(
     recorded, use an appropriate warning filter such as
     ``warnings.simplefilter("always")``.
 
+    When :func:`tpcp.parallel.delayed` captures an active context for execution in a
+    worker process, its fixed metadata and ``record_only`` setting are restored for
+    that task. A propagated ``context_provider`` is evaluated once when the worker
+    task enters the restored context, so all events in that task use the same
+    snapshot. Context providers created inside the worker retain their normal dynamic
+    behavior.
+
     The context manager yields a :class:`WarningErrorContext` whose ``records`` list
     remains available after the context exits. It contains warnings that reached
     Python's warning dispatcher and exceptions that escaped the context. Original
@@ -446,3 +495,10 @@ def iter_with_warning_error_context(
     """
     for i, item in enumerate(iterable):
         yield _make_iteration_context_factory(i), item
+
+
+_register_parallel_context(
+    "warning_error_context",
+    _capture_parallel_context,
+    _restore_parallel_context,
+)

--- a/src/tpcp/misc/_warning_error_context.py
+++ b/src/tpcp/misc/_warning_error_context.py
@@ -8,8 +8,10 @@ from copy import copy
 from dataclasses import dataclass
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypeVar, Union
+from uuid import uuid4
+from weakref import WeakValueDictionary
 
-from tpcp.parallel import _register_parallel_context
+from tpcp.parallel import _register_tpcp_parallel_side_channel
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -67,6 +69,7 @@ class WarningErrorContext(AbstractContextManager["WarningErrorContext"]):
         self._frame: Optional[_ContextFrame] = None
         self._token: Optional[Token] = None
         self._started = False
+        self._parallel_target_id: Optional[str] = None
 
     def start(self) -> WarningErrorContext:
         """Activate the context and return this object.
@@ -197,6 +200,7 @@ class _ParallelContextFrame:
     context: dict[str, Any]
     context_provider: Optional[Callable[[], Mapping[str, Any]]]
     record_only: bool
+    target_id: str
 
     def render(self) -> str:
         rendered_context = _render_context_with_provider(self.context, self.context_provider)
@@ -205,6 +209,7 @@ class _ParallelContextFrame:
 
 _context_stack: ContextVar[tuple[_ContextFrame, ...]] = ContextVar("tpcp_warning_error_context", default=())
 _recorded_error: ContextVar[Optional[BaseException]] = ContextVar("tpcp_warning_error_recorded_error", default=None)
+_parallel_context_targets: WeakValueDictionary[str, WarningErrorContext] = WeakValueDictionary()
 
 
 def _render_context_stack() -> str:
@@ -215,23 +220,59 @@ def _capture_parallel_context() -> Optional[tuple[_ParallelContextFrame, ...]]:
     stack = _context_stack.get()
     if not stack:
         return None
-    return tuple(
-        _ParallelContextFrame(
-            name=frame.name,
-            context=dict(frame.context),
-            context_provider=frame.context_provider,
-            record_only=frame.record_only,
+    captured_frames = []
+    for frame in stack:
+        target_id = frame.result._parallel_target_id
+        if target_id is None:
+            target_id = uuid4().hex
+            frame.result._parallel_target_id = target_id
+        _parallel_context_targets[target_id] = frame.result
+        captured_frames.append(
+            _ParallelContextFrame(
+                name=frame.name,
+                context=dict(frame.context),
+                context_provider=frame.context_provider,
+                record_only=frame.record_only,
+                target_id=target_id,
+            )
         )
-        for frame in stack
-    )
+    return tuple(captured_frames)
+
+
+class _ParallelContextSideChannelData(NamedTuple):
+    target_ids: tuple[str, ...]
+    records: tuple[WarningErrorContextRecord, ...]
 
 
 @contextmanager
-def _restore_parallel_context(context: tuple[_ParallelContextFrame, ...]) -> Iterator[None]:
+def _restore_parallel_context(
+    context: tuple[_ParallelContextFrame, ...],
+) -> Iterator[Callable[[], _ParallelContextSideChannelData]]:
+    active_target_ids = tuple(frame.result._parallel_target_id for frame in _context_stack.get())
+    captured_target_ids = tuple(frame.target_id for frame in context)
+    if active_target_ids == captured_target_ids:
+        yield lambda: _ParallelContextSideChannelData((), ())
+        return
+
     with ExitStack() as stack:
+        restored_contexts = []
         for frame in context:
-            stack.enter_context(warning_error_context(frame.render(), record_only=frame.record_only))
-        yield
+            restored_contexts.append(
+                stack.enter_context(warning_error_context(frame.render(), record_only=frame.record_only))
+            )
+
+        def collect_side_channel_data() -> _ParallelContextSideChannelData:
+            records = () if not restored_contexts else tuple(restored_contexts[0].records)
+            return _ParallelContextSideChannelData(tuple(frame.target_id for frame in context), records)
+
+        yield collect_side_channel_data
+
+
+def _merge_parallel_context_side_channel_data(side_channel_data: _ParallelContextSideChannelData) -> None:
+    for target_id in side_channel_data.target_ids:
+        target = _parallel_context_targets.get(target_id)
+        if target is not None:
+            target.records.extend(side_channel_data.records)
 
 
 def _record_event(
@@ -395,7 +436,12 @@ def warning_error_context(
     that task. A propagated ``context_provider`` is evaluated once when the worker
     task enters the restored context, so all events in that task use the same
     snapshot. Context providers created inside the worker retain their normal dynamic
-    behavior.
+    behavior. When :class:`tpcp.parallel.Parallel` is paired with
+    :func:`tpcp.parallel.delayed`, records from successful tasks are merged back into
+    the original context. Records from a task that raises are not recovered from a
+    separate worker. With ``n_jobs=1``, execution remains inline: providers retain
+    their normal dynamic behavior, and the active parent context directly records
+    exceptions that escape the task.
 
     The context manager yields a :class:`WarningErrorContext` whose ``records`` list
     remains available after the context exits. It contains warnings that reached
@@ -497,8 +543,9 @@ def iter_with_warning_error_context(
         yield _make_iteration_context_factory(i), item
 
 
-_register_parallel_context(
+_register_tpcp_parallel_side_channel(
     "warning_error_context",
     _capture_parallel_context,
     _restore_parallel_context,
+    _merge_parallel_context_side_channel_data,
 )

--- a/src/tpcp/optimize/_optimize.py
+++ b/src/tpcp/optimize/_optimize.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 import numpy as np
-from joblib import Memory, Parallel
+from joblib import Memory
 from numpy.ma import MaskedArray
 from scipy.stats import rankdata
 from sklearn.model_selection import BaseCrossValidator, ParameterGrid
@@ -46,7 +46,7 @@ from tpcp._utils._general import (
 )
 from tpcp._utils._score import _optimize_and_score, _score
 from tpcp.exceptions import PotentialUserErrorWarning
-from tpcp.parallel import delayed
+from tpcp.parallel import Parallel, delayed
 from tpcp.validate import DatasetSplitter
 from tpcp.validate._scorer import ScorerTypes, _validate_scorer
 

--- a/src/tpcp/optimize/_optimize.py
+++ b/src/tpcp/optimize/_optimize.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, nullcontext
 from functools import partial
-from itertools import product
 from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
@@ -46,6 +45,7 @@ from tpcp._utils._general import (
 )
 from tpcp._utils._score import _optimize_and_score, _score
 from tpcp.exceptions import PotentialUserErrorWarning
+from tpcp.misc import iter_with_warning_error_context
 from tpcp.parallel import Parallel, delayed
 from tpcp.validate import DatasetSplitter
 from tpcp.validate._scorer import ScorerTypes, _validate_scorer
@@ -424,26 +424,25 @@ class GridSearch(BaseOptimize[PipelineT, DatasetT], Generic[PipelineT, DatasetT]
         else:
             pbar = _passthrough
 
+        def tasks():
+            for make_context, paras in iter_with_warning_error_context(self.parameter_grid):
+                with make_context("parameter_candidate", {"parameters": paras}):
+                    # delayed snapshots the active context; yield only after it has closed.
+                    task = delayed(_score)(
+                        self.pipeline.clone(),
+                        dataset,
+                        scoring,
+                        paras,
+                        return_parameters=True,
+                        return_data_labels=True,
+                        return_times=True,
+                    )
+                yield task
+
         parallel = Parallel(n_jobs=self.n_jobs, pre_dispatch=self.pre_dispatch, return_as="generator")
         with parallel:
             # Evaluate each parameter combination
-            results = list(
-                pbar(
-                    parallel(
-                        delayed(_score)(
-                            self.pipeline.clone(),
-                            dataset,
-                            scoring,
-                            paras,
-                            return_parameters=True,
-                            return_data_labels=True,
-                            return_times=True,
-                            context=(("parameter_candidate", {"index": candidate_index, "parameters": paras}),),
-                        )
-                        for candidate_index, paras in enumerate(self.parameter_grid)
-                    )
-                )
-            )
+            results = list(pbar(parallel(tasks())))
         assert results is not None  # For the typechecker
         # We check here if all results are dicts. We only check the dtype of the first value, as the scorer should
         # have handled issues with non-uniform cases already.
@@ -798,14 +797,10 @@ class GridSearchCV(
         parameters = list(self.parameter_grid)
         split_parameters = _split_hyper_and_pure_parameters(parameters, pure_parameters)
         parameter_prefix = "pipeline__"
-        combinations = list(
-            product(
-                enumerate(split_parameters),
-                enumerate(cv.split(dataset)),
-            )
-        )
+        splits = list(cv.split(dataset))
 
-        pbar = partial(tqdm, total=len(combinations), desc="Split-Para Combos") if self.progress_bar else _passthrough
+        n_combinations = len(split_parameters) * len(splits)
+        pbar = partial(tqdm, total=n_combinations, desc="Split-Para Combos") if self.progress_bar else _passthrough
 
         # To enable the pure parameter performance improvement, we need to create a joblib cache in a temp dir that
         # is deleted after the run.
@@ -817,18 +812,17 @@ class GridSearchCV(
             tmp_dir_context = TemporaryDirectory("joblib_tpcp_cache")
         with tmp_dir_context as cachedir:
             tmp_cache = Memory(cachedir, verbose=self.verbose) if cachedir else None
-            parallel = Parallel(
-                n_jobs=self.n_jobs,
-                pre_dispatch=self.pre_dispatch,
-                return_as="generator",
-            )
-            # We use a similar structure to sklearn's GridSearchCV here (see GridSearch for more info).
-            with parallel:
-                # Evaluate each parameter combination
-                out = list(
-                    pbar(
-                        parallel(
-                            delayed(_optimize_and_score)(
+
+            def tasks():
+                parameter_iterations = iter_with_warning_error_context(zip(split_parameters, parameters))
+                for make_candidate_context, ((hyper_paras, pure_paras), parameter) in parameter_iterations:
+                    for make_fold_context, (train, test) in iter_with_warning_error_context(splits):
+                        with (
+                            make_candidate_context("parameter_candidate", {"parameters": parameter}),
+                            make_fold_context("cv_fold"),
+                        ):
+                            # delayed snapshots both contexts; yield only after they have closed.
+                            task = delayed(_optimize_and_score)(
                                 optimizer.clone(),
                                 scoring,
                                 dataset[train],
@@ -841,21 +835,18 @@ class GridSearchCV(
                                 return_data_labels=True,
                                 return_times=True,
                                 memory=tmp_cache,
-                                context=(
-                                    (
-                                        "parameter_candidate",
-                                        {"index": cand_idx, "parameters": parameters[cand_idx]},
-                                    ),
-                                    ("cv_fold", {"index": split_idx}),
-                                ),
                             )
-                            for (cand_idx, (hyper_paras, pure_paras)), (
-                                split_idx,
-                                (train, test),
-                            ) in combinations
-                        )
-                    )
-                )
+                        yield task
+
+            parallel = Parallel(
+                n_jobs=self.n_jobs,
+                pre_dispatch=self.pre_dispatch,
+                return_as="generator",
+            )
+            # We use a similar structure to sklearn's GridSearchCV here (see GridSearch for more info).
+            with parallel:
+                # Evaluate each parameter combination
+                out = list(pbar(parallel(tasks())))
         assert out is not None  # For the type checker
         results = self._format_results(parameters, n_splits, out)
         self.cv_results_ = results

--- a/src/tpcp/optimize/optuna.py
+++ b/src/tpcp/optimize/optuna.py
@@ -15,7 +15,6 @@ from collections.abc import Sequence
 from typing import Any, Callable, Optional, TypedDict, TypeVar, Union
 
 import numpy as np
-from joblib import Parallel
 from optuna import Study
 from optuna.study import StudyDirection
 from optuna.study.study import ObjectiveFuncType
@@ -28,7 +27,7 @@ from tpcp._optimize import BaseOptimize
 from tpcp._pipeline import PipelineT
 from tpcp.misc import warning_error_context
 from tpcp.optimize import Optimize
-from tpcp.parallel import delayed
+from tpcp.parallel import Parallel, delayed
 from tpcp.validate._scorer import ScorerTypes, _validate_scorer
 
 __all__ = ["CustomOptunaOptimize", "CustomOptunaOptimizeT", "OptunaSearch"]

--- a/src/tpcp/parallel.py
+++ b/src/tpcp/parallel.py
@@ -13,13 +13,34 @@ However, you can likely configure the callbacks in tpcp to make that work.
 
 import functools
 import multiprocessing
-from typing import Callable, TypeVar
+import warnings
+from contextlib import AbstractContextManager, ExitStack
+from dataclasses import dataclass
+from typing import Any, Callable, TypeVar
 
 import joblib
 
 T = TypeVar("T")
 CalbackReturnType = tuple[T, Callable[[T], None]]
 _PARALLEL_CONTEXT_CALLBACKS: dict[str, [Callable[[], CalbackReturnType]]] = {}
+
+
+@dataclass(frozen=True)
+class _ParallelContextHooks:
+    capture: Callable[[], Any]
+    restore: Callable[[Any], AbstractContextManager[Any]]
+
+
+_PARALLEL_CONTEXT_HOOKS: dict[str, _ParallelContextHooks] = {}
+
+
+def _register_parallel_context(
+    name: str,
+    capture: Callable[[], Any],
+    restore: Callable[[Any], AbstractContextManager[Any]],
+) -> None:
+    """Register an internal context that is scoped to a single worker task."""
+    _PARALLEL_CONTEXT_HOOKS[name] = _ParallelContextHooks(capture, restore)
 
 
 def delayed(func):
@@ -77,18 +98,35 @@ def delayed(func):
     Setters might be called multiple times in the same process, if the process pool is reused by multiple jobs.
     The callbacks should be robust against this and not break.
 
+    Active :func:`~tpcp.misc.warning_error_context` instances are restored automatically for each worker task.
+    Their worker-side lifetime is limited to that task, even when joblib reuses the process.
+    The Python warning filters active when the delayed task is created are restored in process workers.
+    Thread workers share process-global warning filters and therefore use the filters active when the task executes.
+
     """
     _parallel_setter = []
     for g in _PARALLEL_CONTEXT_CALLBACKS.values():
         _parallel_setter.append(g())
+    warning_filters = list(warnings.filters)
+    parallel_contexts = []
+    for hooks in _PARALLEL_CONTEXT_HOOKS.values():
+        captured_context = hooks.capture()
+        if captured_context is not None:
+            parallel_contexts.append((captured_context, hooks.restore))
 
     @functools.wraps(func)
     def inner(*args, **kwargs):
         # When the function is called in the main process, we just call the function
         # Otherwise we actually run our setters.
         if multiprocessing.parent_process() is not None:
-            for value, setter in _parallel_setter:
-                setter(value)
+            with warnings.catch_warnings(), ExitStack() as stack:
+                warnings.filters[:] = warning_filters
+                warnings._filters_mutated()
+                for value, setter in _parallel_setter:
+                    setter(value)
+                for captured_context, restore in parallel_contexts:
+                    stack.enter_context(restore(captured_context))
+                return func(*args, **kwargs)
         return func(*args, **kwargs)
 
     return joblib.delayed(inner)

--- a/src/tpcp/parallel.py
+++ b/src/tpcp/parallel.py
@@ -1,10 +1,10 @@
 """Helpers for restoring TPCP runtime context in joblib workers.
 
 The worker-state helpers are required as long as https://github.com/joblib/joblib/issues/1071 is not resolved.
-:func:`delayed` restores registered state for each worker task. :class:`Parallel`
-additionally recovers side-channel data from successful tasks without changing their
-return values. Applications can add their own round-trip state with
-:func:`register_parallel_side_channel`.
+The :func:`delayed` wrapper restores registered global state, Python warning filters,
+and active warning/error contexts for each worker task. :class:`Parallel` additionally
+recovers side-channel data from successful tasks without changing their return values.
+Applications can add their own round-trip state with :func:`register_parallel_side_channel`.
 
 The provided workarounds are similar to the ones done in scikit-learn
 (https://github.com/scikit-learn/scikit-learn/pull/25363).

--- a/src/tpcp/parallel.py
+++ b/src/tpcp/parallel.py
@@ -1,6 +1,10 @@
-"""A set of helper functions to correctly handle global variables in parallel processes.
+"""Helpers for restoring TPCP runtime context in joblib workers.
 
-Both functions are required as long as https://github.com/joblib/joblib/issues/1071 is not resolved.
+The worker-state helpers are required as long as https://github.com/joblib/joblib/issues/1071 is not resolved.
+:func:`delayed` restores registered state for each worker task. :class:`Parallel`
+additionally recovers side-channel data from successful tasks without changing their
+return values. Applications can add their own round-trip state with
+:func:`register_parallel_side_channel`.
 
 The provided workarounds are similar to the ones done in scikit-learn
 (https://github.com/scikit-learn/scikit-learn/pull/25363).
@@ -11,36 +15,137 @@ The same way, by default tpcp will not forward sklearn global configs through tp
 However, you can likely configure the callbacks in tpcp to make that work.
 """
 
+from __future__ import annotations
+
 import functools
 import multiprocessing
 import warnings
 from contextlib import AbstractContextManager, ExitStack
+from contextvars import Context, ContextVar, copy_context
 from dataclasses import dataclass
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import joblib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 T = TypeVar("T")
 CalbackReturnType = tuple[T, Callable[[T], None]]
 _PARALLEL_CONTEXT_CALLBACKS: dict[str, [Callable[[], CalbackReturnType]]] = {}
+_TPCP_PARALLEL_NAME_PREFIX = "__tpcp_internal__."
 
 
 @dataclass(frozen=True)
-class _ParallelContextHooks:
+class _ParallelSideChannel:
     capture: Callable[[], Any]
-    restore: Callable[[Any], AbstractContextManager[Any]]
+    restore: Callable[[Any], AbstractContextManager[Callable[[], Any]]]
+    merge: Callable[[Any], None]
 
 
-_PARALLEL_CONTEXT_HOOKS: dict[str, _ParallelContextHooks] = {}
+_PARALLEL_SIDE_CHANNELS: dict[str, _ParallelSideChannel] = {}
 
 
-def _register_parallel_context(
+def _tpcp_parallel_name(name: str) -> str:
+    return f"{_TPCP_PARALLEL_NAME_PREFIX}{name}"
+
+
+def _register_tpcp_global_parallel_callback(name: str, callback: Callable[[], CalbackReturnType]) -> None:
+    """Register a TPCP-owned one-way callback in the reserved namespace."""
+    _PARALLEL_CONTEXT_CALLBACKS[_tpcp_parallel_name(name)] = callback
+
+
+def _remove_tpcp_global_parallel_callback(name: str) -> None:
+    """Remove a TPCP-owned one-way callback from the reserved namespace."""
+    del _PARALLEL_CONTEXT_CALLBACKS[_tpcp_parallel_name(name)]
+
+
+def _register_tpcp_parallel_side_channel(
     name: str,
     capture: Callable[[], Any],
-    restore: Callable[[Any], AbstractContextManager[Any]],
+    restore: Callable[[Any], AbstractContextManager[Callable[[], Any]]],
+    merge: Callable[[Any], None],
 ) -> None:
-    """Register an internal context that is scoped to a single worker task."""
-    _PARALLEL_CONTEXT_HOOKS[name] = _ParallelContextHooks(capture, restore)
+    """Register a TPCP-owned side channel, replacing it on module reload."""
+    _PARALLEL_SIDE_CHANNELS[_tpcp_parallel_name(name)] = _ParallelSideChannel(capture, restore, merge)
+
+
+@dataclass(frozen=True)
+class _ParallelResult:
+    value: Any
+    side_channel_data: tuple[tuple[str, Any], ...]
+
+
+_parallel_side_channels_enabled: ContextVar[bool] = ContextVar("tpcp_parallel_side_channels_enabled", default=False)
+
+
+def _are_parallel_side_channels_enabled() -> bool:
+    return _parallel_side_channels_enabled.get()
+
+
+def _run_with_parallel_side_channels(func: Callable, args: tuple, kwargs: dict) -> Any:
+    token = _parallel_side_channels_enabled.set(True)
+    try:
+        return func(*args, **kwargs)
+    finally:
+        _parallel_side_channels_enabled.reset(token)
+
+
+def _call_with_parallel_side_channels(func: Callable, args: tuple, kwargs: dict, side_channels: Iterable) -> Any:
+    with ExitStack() as stack:
+        collectors = [
+            (name, stack.enter_context(restore(captured_state))) for name, captured_state, restore in side_channels
+        ]
+        result = func(*args, **kwargs)
+        if _are_parallel_side_channels_enabled():
+            side_channel_data = tuple((name, collect()) for name, collect in collectors)
+            return _ParallelResult(result, side_channel_data)
+        return result
+
+
+class _ParallelTaskIterator:
+    def __init__(self, iterable: Iterable, context: Context) -> None:
+        self._iterator = iter(iterable)
+        self._context = context
+
+    def __iter__(self) -> Iterator:
+        return self
+
+    def __next__(self):
+        func, args, kwargs = self._context.copy().run(next, self._iterator)
+        return _run_with_parallel_side_channels, (func, args, kwargs), {}
+
+
+def _merge_parallel_side_channel_data(result: Any) -> Any:
+    if not isinstance(result, _ParallelResult):
+        return result
+    for name, side_channel_data in result.side_channel_data:
+        _PARALLEL_SIDE_CHANNELS[name].merge(side_channel_data)
+    return result.value
+
+
+class Parallel(joblib.Parallel):
+    """Run joblib tasks and recover side-channel data from TPCP worker contexts.
+
+    This is a drop-in :class:`joblib.Parallel` subclass. When paired with
+    :func:`delayed`, side-channel data produced by a successfully completed worker
+    task is merged back into parent-process state. This includes records produced by
+    restored warning/error contexts. Generator results are merged lazily as they are
+    consumed.
+
+    Side-channel data from a task that raises is not recovered; joblib propagates the original
+    exception unchanged. The exception still retains context added inside the worker.
+    Plain :class:`joblib.Parallel` remains supported with :func:`delayed`, but does not
+    recover worker side-channel data.
+
+    """
+
+    def __call__(self, iterable):
+        """Dispatch delayed tasks and merge side-channel data in the parent."""
+        results = super().__call__(_ParallelTaskIterator(iterable, copy_context()))
+        if self.return_generator:
+            return (_merge_parallel_side_channel_data(result) for result in results)
+        return [_merge_parallel_side_channel_data(result) for result in results]
 
 
 def delayed(func):
@@ -64,8 +169,15 @@ def delayed(func):
     used in tpcp.
     Note, sklearn has a custom workaround for this, which is not compatible with tpcp.
 
-    >>> from tpcp.parallel import delayed, register_global_parallel_callback
-    >>> from joblib import Parallel
+    >>> from contextlib import contextmanager
+    >>> from tpcp.parallel import (
+    ...     Parallel,
+    ...     delayed,
+    ...     register_global_parallel_callback,
+    ...     register_parallel_side_channel,
+    ...     remove_global_parallel_callback,
+    ...     remove_parallel_side_channel,
+    ... )
     >>> from sklearn import get_config, set_config
     >>>
     >>> set_config(assume_finite=True)
@@ -88,6 +200,28 @@ def delayed(func):
     [True, True]
     >>> # remove the callback again
     >>> remove_global_parallel_callback(name)
+    >>>
+    >>> # A side channel can additionally return data from successful worker tasks.
+    >>> worker_events = []
+    >>> collected_events = []
+    >>> @contextmanager
+    ... def restore_events(run_name):
+    ...     worker_events.clear()
+    ...     try:
+    ...         yield lambda: tuple((run_name, event) for event in worker_events)
+    ...     finally:
+    ...         worker_events.clear()
+    >>> def worker_with_event(value):
+    ...     worker_events.append(f"processed {value}")
+    ...     return value * 2
+    >>> side_channel = register_parallel_side_channel(
+    ...     lambda: "experiment-1", restore_events, collected_events.extend
+    ... )
+    >>> Parallel(n_jobs=2)(delayed(worker_with_event)(value) for value in range(2))
+    [0, 2]
+    >>> collected_events
+    [('experiment-1', 'processed 0'), ('experiment-1', 'processed 1')]
+    >>> remove_parallel_side_channel(side_channel)
 
     Notes
     -----
@@ -102,34 +236,100 @@ def delayed(func):
     Their worker-side lifetime is limited to that task, even when joblib reuses the process.
     The Python warning filters active when the delayed task is created are restored in process workers.
     Thread workers share process-global warning filters and therefore use the filters active when the task executes.
+    Use :func:`register_parallel_side_channel` for custom state that must be restored
+    for one worker task and optionally returned to the parent process.
 
     """
     _parallel_setter = []
     for g in _PARALLEL_CONTEXT_CALLBACKS.values():
         _parallel_setter.append(g())
-    warning_filters = list(warnings.filters)
-    parallel_contexts = []
-    for hooks in _PARALLEL_CONTEXT_HOOKS.values():
-        captured_context = hooks.capture()
-        if captured_context is not None:
-            parallel_contexts.append((captured_context, hooks.restore))
 
     @functools.wraps(func)
-    def inner(*args, **kwargs):
-        # When the function is called in the main process, we just call the function
-        # Otherwise we actually run our setters.
-        if multiprocessing.parent_process() is not None:
-            with warnings.catch_warnings(), ExitStack() as stack:
-                warnings.filters[:] = warning_filters
-                warnings._filters_mutated()
-                for value, setter in _parallel_setter:
-                    setter(value)
-                for captured_context, restore in parallel_contexts:
-                    stack.enter_context(restore(captured_context))
-                return func(*args, **kwargs)
-        return func(*args, **kwargs)
+    def create_task(*task_args, **task_kwargs):
+        warning_filters = list(warnings.filters)
+        parallel_side_channels = []
+        for name, side_channel in _PARALLEL_SIDE_CHANNELS.items():
+            captured_state = side_channel.capture()
+            if captured_state is not None:
+                parallel_side_channels.append((name, captured_state, side_channel.restore))
 
-    return joblib.delayed(inner)
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            if multiprocessing.parent_process() is not None:
+                with warnings.catch_warnings():
+                    warnings.filters[:] = warning_filters
+                    warnings._filters_mutated()
+                    for value, setter in _parallel_setter:
+                        setter(value)
+                    return _call_with_parallel_side_channels(func, args, kwargs, parallel_side_channels)
+            if _are_parallel_side_channels_enabled():
+                return _call_with_parallel_side_channels(func, args, kwargs, parallel_side_channels)
+            return func(*args, **kwargs)
+
+        return joblib.delayed(inner)(*task_args, **task_kwargs)
+
+    return create_task
+
+
+def register_parallel_side_channel(
+    capture: Callable[[], Any],
+    restore: Callable[[Any], AbstractContextManager[Callable[[], Any]]],
+    merge: Callable[[Any], None],
+    name: str | None = None,
+) -> str:
+    """Register state that can make a round trip through a parallel worker.
+
+    ``capture`` is called when :func:`delayed` creates a task. If it returns
+    ``None``, the side channel is inactive for that task. Otherwise, ``restore``
+    receives the captured state in the worker and must return a context manager.
+    The callable yielded by that context manager is invoked after a successful
+    task to collect side-channel data. When :class:`Parallel` consumes the task
+    result, ``merge`` receives that data in the parent process.
+
+    Plain :class:`joblib.Parallel` still enters the worker context, but does not
+    collect or merge side-channel data. A task that raises does not return its
+    side-channel data either.
+
+    Parameters
+    ----------
+    capture
+        Capture parent-process state for one delayed task. Return ``None`` to
+        disable this side channel for that task.
+    restore
+        Create the context manager that restores the captured state around one
+        worker task. It must yield a zero-argument collector callable.
+    merge
+        Merge the collector result into parent-process state.
+    name
+        Optional registration name used to remove the side channel again. Names
+        beginning with ``"__tpcp_internal__."`` are reserved for TPCP.
+
+    Returns
+    -------
+    str
+        The registration name for :func:`remove_parallel_side_channel`.
+
+    """
+    if name is None:
+        name = str(id(capture))
+    _validate_public_parallel_name(name)
+    if name in _PARALLEL_SIDE_CHANNELS:
+        raise ValueError(f"Parallel side channel with name {name} already registered.")
+    _PARALLEL_SIDE_CHANNELS[name] = _ParallelSideChannel(capture, restore, merge)
+    return name
+
+
+def remove_parallel_side_channel(name: str) -> None:
+    """Remove a side channel registered with :func:`register_parallel_side_channel`."""
+    _validate_public_parallel_name(name)
+    if name not in _PARALLEL_SIDE_CHANNELS:
+        raise KeyError(f"Parallel side channel with name {name} not found.")
+    del _PARALLEL_SIDE_CHANNELS[name]
+
+
+def _validate_public_parallel_name(name: str) -> None:
+    if name.startswith(_TPCP_PARALLEL_NAME_PREFIX):
+        raise ValueError(f"Names beginning with {_TPCP_PARALLEL_NAME_PREFIX!r} are reserved for TPCP.")
 
 
 def register_global_parallel_callback(callback: Callable[[], tuple[T, Callable[[T], None]]], name=None) -> str:
@@ -155,7 +355,8 @@ def register_global_parallel_callback(callback: Callable[[], tuple[T, Callable[[
         Optional name of the callback function.
         This can be used to remove the callback again.
         If None a random name will be used.
-        The random name can be obtained via the return value
+        The random name can be obtained via the return value. Names beginning with
+        ``"__tpcp_internal__."`` are reserved for TPCP.
 
     Returns
     -------
@@ -166,6 +367,7 @@ def register_global_parallel_callback(callback: Callable[[], tuple[T, Callable[[
     if name is None:
         # Generate random name
         name = str(id(callback))
+    _validate_public_parallel_name(name)
     if name in _PARALLEL_CONTEXT_CALLBACKS:
         raise ValueError(f"Callback with name {name} already registered.")
     _PARALLEL_CONTEXT_CALLBACKS[name] = callback
@@ -185,10 +387,18 @@ def remove_global_parallel_callback(name: str):
         The name of the callback that should be removed.
 
     """
+    _validate_public_parallel_name(name)
     if name in _PARALLEL_CONTEXT_CALLBACKS:
         del _PARALLEL_CONTEXT_CALLBACKS[name]
     else:
         raise KeyError(f"Callback with name {name} not found.")
 
 
-__all__ = ["delayed", "register_global_parallel_callback", "remove_global_parallel_callback"]
+__all__ = [
+    "Parallel",
+    "delayed",
+    "register_global_parallel_callback",
+    "register_parallel_side_channel",
+    "remove_global_parallel_callback",
+    "remove_parallel_side_channel",
+]

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -16,7 +16,6 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-from joblib import Parallel
 from tqdm.auto import tqdm
 from typing_extensions import Protocol, Self
 
@@ -28,7 +27,7 @@ from tpcp._pipeline import PipelineT
 from tpcp._utils._general import _passthrough
 from tpcp.exceptions import ScorerFailedError, ValidationError
 from tpcp.misc import iter_with_warning_error_context, warning_error_context
-from tpcp.parallel import delayed
+from tpcp.parallel import Parallel, delayed
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -437,16 +437,18 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
             n_jobs=self.n_jobs, verbose=self.verbose, pre_dispatch=self.pre_dispatch, return_as="generator"
         )
         with parallel:
-            for i, r in pbar(parallel(delayed(per_datapoint)(i, d) for i, d in enumerate(dataset))):
+            score_results = pbar(parallel(delayed(per_datapoint)(i, d) for i, d in enumerate(dataset)))
+            for make_context, (i, r) in iter_with_warning_error_context(score_results):
                 scores.append(r)
                 if self.single_score_callback:
-                    self.single_score_callback(
-                        step=i,
-                        scores=tuple(scores),
-                        scorer=self,
-                        pipeline=pipeline,
-                        dataset=dataset,
-                    )
+                    with make_context("single_score_callback"):
+                        self.single_score_callback(
+                            step=i,
+                            scores=tuple(scores),
+                            scorer=self,
+                            pipeline=pipeline,
+                            dataset=dataset,
+                        )
 
         agg_scores, raw_scores = self._aggregate(
             _check_and_invert_score_dict(scores, self.default_aggregator), list(dataset)

--- a/src/tpcp/validate/_scorer.py
+++ b/src/tpcp/validate/_scorer.py
@@ -27,7 +27,7 @@ from tpcp._hash import custom_hash
 from tpcp._pipeline import PipelineT
 from tpcp._utils._general import _passthrough
 from tpcp.exceptions import ScorerFailedError, ValidationError
-from tpcp.misc import warning_error_context
+from tpcp.misc import iter_with_warning_error_context, warning_error_context
 from tpcp.parallel import delayed
 
 if TYPE_CHECKING:
@@ -374,25 +374,26 @@ class Scorer(Generic[PipelineT, DatasetT], BaseTpcpObject):
 
         raw_scores: dict[str, list] = {}
         agg_scores: dict[str, float] = {}
-        for name, (aggregator, raw_score) in scores.items():
-            if aggregator.return_raw_scores is True:
-                raw_scores[name] = list(raw_score)
-            try:
-                agg_score = aggregator.aggregate(values=raw_score, datapoints=datapoints)
-            except Exception as e:
-                raise ValidationError(
-                    f"Aggregator for score '{name}' raised an exception while aggregating scores. "
-                    "Scroll up to see the original exception."
-                ) from e
-            if agg_score is NOTHING or isinstance(agg_score, _Nothing):
-                # This is the case with the NoAgg Scorer
-                continue
-            if isinstance(agg_score, dict):
-                # If the aggregator returned multiple values, we merge them prefixing the original name
-                for key, value in agg_score.items():
-                    agg_scores[key if is_single else f"{name}__{key}"] = value
-            else:
-                agg_scores[name] = agg_score
+        for make_context, (name, (aggregator, raw_score)) in iter_with_warning_error_context(scores.items()):
+            with make_context("score_aggregation", {"score_name": name}):
+                if aggregator.return_raw_scores is True:
+                    raw_scores[name] = list(raw_score)
+                try:
+                    agg_score = aggregator.aggregate(values=raw_score, datapoints=datapoints)
+                except Exception as e:
+                    raise ValidationError(
+                        f"Aggregator for score '{name}' raised an exception while aggregating scores. "
+                        "Scroll up to see the original exception."
+                    ) from e
+                if agg_score is NOTHING or isinstance(agg_score, _Nothing):
+                    # This is the case with the NoAgg Scorer
+                    continue
+                if isinstance(agg_score, dict):
+                    # If the aggregator returned multiple values, we merge them prefixing the original name
+                    for key, value in agg_score.items():
+                        agg_scores[key if is_single else f"{name}__{key}"] = value
+                else:
+                    agg_scores[name] = agg_score
         # Finally we check that all aggregates values are floats
         if not all(isinstance(score, (int, float)) for score in agg_scores.values()):
             raise ValidationError(

--- a/src/tpcp/validate/_validate.py
+++ b/src/tpcp/validate/_validate.py
@@ -13,6 +13,7 @@ from tpcp._optimize import BaseOptimize
 from tpcp._pipeline import PipelineT
 from tpcp._utils._general import _aggregate_final_results, _normalize_score_results, _passthrough, _prefix_para_dict
 from tpcp._utils._score import _optimize_and_score, _score
+from tpcp.misc import iter_with_warning_error_context
 from tpcp.parallel import Parallel, delayed
 from tpcp.validate._cross_val_helper import DatasetSplitter
 from tpcp.validate._scorer import ScoreFunc, Scorer, ScorerTypes, _validate_scorer
@@ -120,31 +121,30 @@ def cross_validate(
 
     pbar = partial(tqdm, total=len(splits), desc="CV Folds") if progress_bar else _passthrough
 
+    def tasks():
+        for make_context, (train, test) in iter_with_warning_error_context(splits):
+            with make_context("cv_fold"):
+                # delayed snapshots the active context; yield only after it has closed.
+                task = delayed(_optimize_and_score)(
+                    # We clone the estimator to make sure that all the folds are
+                    # independent, and that it is pickle-able.
+                    optimizable.clone(),
+                    scoring,
+                    dataset[train],
+                    dataset[test],
+                    optimize_params=optimize_params,
+                    hyperparameters=None,
+                    pure_parameters=None,
+                    return_train_score=return_train_score,
+                    return_times=True,
+                    return_data_labels=True,
+                    return_optimizer=return_optimizer,
+                )
+            yield task
+
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose, pre_dispatch=pre_dispatch, return_as="generator")
     with parallel:
-        results = list(
-            pbar(
-                parallel(
-                    delayed(_optimize_and_score)(
-                        # We clone the estimator to make sure that all the folds are
-                        # independent, and that it is pickle-able.
-                        optimizable.clone(),
-                        scoring,
-                        dataset[train],
-                        dataset[test],
-                        optimize_params=optimize_params,
-                        hyperparameters=None,
-                        pure_parameters=None,
-                        return_train_score=return_train_score,
-                        return_times=True,
-                        return_data_labels=True,
-                        return_optimizer=return_optimizer,
-                        context=(("cv_fold", {"index": i}),),
-                    )
-                    for i, (train, test) in enumerate(splits)
-                )
-            )
-        )
+        results = list(pbar(parallel(tasks())))
     assert results is not None  # For the typechecker
     results = _aggregate_final_results(results)
 

--- a/src/tpcp/validate/_validate.py
+++ b/src/tpcp/validate/_validate.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from functools import partial
 from typing import Any, Optional, Union
 
-from joblib import Parallel
 from sklearn.model_selection import BaseCrossValidator
 from tqdm.auto import tqdm
 
@@ -14,7 +13,7 @@ from tpcp._optimize import BaseOptimize
 from tpcp._pipeline import PipelineT
 from tpcp._utils._general import _aggregate_final_results, _normalize_score_results, _passthrough, _prefix_para_dict
 from tpcp._utils._score import _optimize_and_score, _score
-from tpcp.parallel import delayed
+from tpcp.parallel import Parallel, delayed
 from tpcp.validate._cross_val_helper import DatasetSplitter
 from tpcp.validate._scorer import ScoreFunc, Scorer, ScorerTypes, _validate_scorer
 

--- a/tests/_config_test.py
+++ b/tests/_config_test.py
@@ -1,6 +1,9 @@
 """A test module required by the test_global_parallel_callback.py test."""
 
+from contextlib import contextmanager
+
 _GLOBAL_CONFIG = None
+_SIDE_CHANNEL = []
 
 
 def set_config(value):
@@ -10,3 +13,17 @@ def set_config(value):
 
 def config():
     return _GLOBAL_CONFIG
+
+
+@contextmanager
+def restore_side_channel(prefix):
+    _SIDE_CHANNEL.clear()
+    try:
+        yield lambda: tuple((prefix, value) for value in _SIDE_CHANNEL)
+    finally:
+        _SIDE_CHANNEL.clear()
+
+
+def add_to_side_channel(value):
+    _SIDE_CHANNEL.append(value)
+    return value

--- a/tests/test_global_parallel_callback.py
+++ b/tests/test_global_parallel_callback.py
@@ -5,10 +5,16 @@ import warnings
 import joblib
 import pytest
 
-from tests._config_test import config, set_config
+from tests._config_test import add_to_side_channel, config, restore_side_channel, set_config
 from tpcp import parallel
-from tpcp.misc import warning_error_context
-from tpcp.parallel import delayed, register_global_parallel_callback
+from tpcp.misc import print_with_context, warning_error_context
+from tpcp.parallel import (
+    Parallel,
+    delayed,
+    register_global_parallel_callback,
+    register_parallel_side_channel,
+    remove_parallel_side_channel,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -80,7 +86,8 @@ def test_warning_context_record_only_setting_is_restored_in_worker_process():
     assert result == [0]
 
 
-def test_warning_context_annotates_worker_process_error():
+@pytest.mark.parametrize("parallel_class", [joblib.Parallel, Parallel])
+def test_warning_context_annotates_worker_process_error(parallel_class):
     def fail_in_worker():
         raise RuntimeError("worker failed")
 
@@ -88,7 +95,7 @@ def test_warning_context_annotates_worker_process_error():
         warning_error_context("parent", {"item": 3}),
         pytest.raises(RuntimeError, match="worker failed") as error,
     ):
-        joblib.Parallel(n_jobs=2)(delayed(fail_in_worker)() for _ in range(1))
+        parallel_class(n_jobs=2)(delayed(fail_in_worker)() for _ in range(1))
 
     assert error.value.__notes__ == ["Context: parent: item=3"]
 
@@ -146,6 +153,101 @@ def test_warning_filter_changes_from_callback_setter_do_not_leak():
 
     assert filtered_result == [0, 0]
     assert restored_result == [1, 1]
+
+
+@pytest.mark.parametrize(("n_jobs", "backend"), [(1, None), (2, None), (2, "threading")])
+def test_tpcp_parallel_recovers_worker_context_records(n_jobs, backend):
+    def report_from_worker():
+        warnings.warn("worker warning", UserWarning, stacklevel=1)
+        print_with_context("worker print")
+        return "worker result"
+
+    with warning_error_context("parent", {"run": 1}, record_only=True) as context:
+        result = Parallel(n_jobs=n_jobs, backend=backend)(delayed(report_from_worker)() for _ in range(1))
+
+    assert result == ["worker result"]
+    assert [(record.type, record.context, str(record.message)) for record in context.records] == [
+        ("warning", "parent: run=1", "worker warning"),
+        ("print", "parent: run=1", "worker print"),
+    ]
+    assert isinstance(context.records[0].message, UserWarning)
+
+
+def test_reused_delayed_callable_captures_context_when_each_task_is_created():
+    def report_from_worker(label):
+        print_with_context(label)
+        return label
+
+    task = delayed(report_from_worker)
+    with warning_error_context("first", record_only=True) as first_context:
+        first_task = task("first task")
+    with warning_error_context("second", record_only=True) as second_context:
+        second_task = task("second task")
+
+    assert Parallel(n_jobs=2)([first_task, second_task]) == ["first task", "second task"]
+    assert [(record.context, record.message) for record in first_context.records] == [("first", "first task")]
+    assert [(record.context, record.message) for record in second_context.records] == [("second", "second task")]
+
+
+def test_tpcp_parallel_recovers_records_as_generator_is_consumed():
+    def report_from_worker(i):
+        warnings.warn(f"worker warning {i}", UserWarning, stacklevel=1)
+        return i
+
+    with warning_error_context("parent", record_only=True) as context:
+        results = Parallel(n_jobs=2, return_as="generator")(delayed(report_from_worker)(i) for i in range(5))
+        assert context.records == []
+        assert list(results) == list(range(5))
+
+    assert [str(record.message) for record in context.records] == [f"worker warning {i}" for i in range(5)]
+
+
+def test_joblib_parallel_does_not_expose_or_recover_tpcp_side_channel_data():
+    def report_from_worker():
+        warnings.warn("worker warning", UserWarning, stacklevel=1)
+        return "worker result"
+
+    with warning_error_context("parent", record_only=True) as context:
+        result = joblib.Parallel(n_jobs=2)(delayed(report_from_worker)() for _ in range(1))
+
+    assert result == ["worker result"]
+    assert context.records == []
+
+
+@pytest.mark.parametrize(("n_jobs", "backend"), [(1, None), (2, None), (2, "threading")])
+def test_custom_parallel_side_channel_restores_worker_state_and_collects_results(n_jobs, backend):
+    collected = []
+    name = register_parallel_side_channel(
+        lambda: "captured state",
+        restore_side_channel,
+        collected.extend,
+    )
+    try:
+        results = Parallel(n_jobs=n_jobs, backend=backend)(delayed(add_to_side_channel)(i) for i in range(3))
+    finally:
+        remove_parallel_side_channel(name)
+
+    assert results == [0, 1, 2]
+    assert collected == [("captured state", 0), ("captured state", 1), ("captured state", 2)]
+
+
+@pytest.mark.parametrize(
+    "register",
+    [
+        lambda: register_global_parallel_callback(lambda: (None, lambda _: None), name="__tpcp_internal__.custom"),
+        lambda: register_parallel_side_channel(
+            lambda: None,
+            restore_side_channel,
+            lambda _: None,
+            name="__tpcp_internal__.custom",
+        ),
+        lambda: parallel.remove_global_parallel_callback("__tpcp_internal__.custom"),
+        lambda: remove_parallel_side_channel("__tpcp_internal__.custom"),
+    ],
+)
+def test_tpcp_parallel_prefix_is_reserved(register):
+    with pytest.raises(ValueError, match="reserved for TPCP"):
+        register()
 
 
 def test_doctest():

--- a/tests/test_global_parallel_callback.py
+++ b/tests/test_global_parallel_callback.py
@@ -1,10 +1,13 @@
 import doctest
+import time
+import warnings
 
 import joblib
 import pytest
 
 from tests._config_test import config, set_config
 from tpcp import parallel
+from tpcp.misc import warning_error_context
 from tpcp.parallel import delayed, register_global_parallel_callback
 
 
@@ -36,6 +39,113 @@ def test_simple_callback():
     register_global_parallel_callback(callback)
 
     assert joblib.Parallel(n_jobs=2)(delayed(func)() for _ in range(2)) == ["set", "set"]
+
+
+def test_warning_context_is_restored_in_worker_process():
+    provider_state = {"calls": 0}
+
+    def context_provider():
+        provider_state["calls"] += 1
+        return {"provider_call": provider_state["calls"]}
+
+    def warn_in_worker():
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warnings.warn("first", UserWarning, stacklevel=1)
+            warnings.warn("second", UserWarning, stacklevel=1)
+        return [str(warning.message) for warning in caught]
+
+    with warning_error_context("parent", {"fixed": "value"}, context_provider=context_provider):
+        result = joblib.Parallel(n_jobs=2)(delayed(warn_in_worker)() for _ in range(1))
+
+    expected_context = "parent: fixed='value', provider_call=1"
+    assert result == [
+        [
+            f"first\n[{expected_context}] first",
+            f"second\n[{expected_context}] second",
+        ]
+    ]
+
+
+def test_warning_context_record_only_setting_is_restored_in_worker_process():
+    def warn_in_worker():
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warnings.warn("worker warning", UserWarning, stacklevel=1)
+        return len(caught)
+
+    with warning_error_context("parent", record_only=True):
+        result = joblib.Parallel(n_jobs=2)(delayed(warn_in_worker)() for _ in range(1))
+
+    assert result == [0]
+
+
+def test_warning_context_annotates_worker_process_error():
+    def fail_in_worker():
+        raise RuntimeError("worker failed")
+
+    with (
+        warning_error_context("parent", {"item": 3}),
+        pytest.raises(RuntimeError, match="worker failed") as error,
+    ):
+        joblib.Parallel(n_jobs=2)(delayed(fail_in_worker)() for _ in range(1))
+
+    assert error.value.__notes__ == ["Context: parent: item=3"]
+
+
+def test_warning_filters_are_restored_in_worker_process():
+    def warn_in_worker(delay=0):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.warn("worker warning", UserWarning, stacklevel=1)
+        time.sleep(delay)
+        return len(caught)
+
+    with joblib.Parallel(n_jobs=2, batch_size=1) as parallel:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = parallel(delayed(warn_in_worker)(0.1) for _ in range(4))
+        restored_result = parallel(joblib.delayed(warn_in_worker)() for _ in range(4))
+
+    assert result == [0, 0, 0, 0]
+    assert restored_result == [1, 1, 1, 1]
+
+
+def test_warning_filters_are_not_overridden_in_worker_threads():
+    def warn_in_worker():
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.warn("worker warning", UserWarning, stacklevel=1)
+        return len(caught)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        task = delayed(warn_in_worker)()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always", UserWarning)
+        result = joblib.Parallel(n_jobs=2, backend="threading")([task])
+
+    assert result == [1]
+
+
+def test_warning_filter_changes_from_callback_setter_do_not_leak():
+    def callback():
+        def setter(_):
+            warnings.simplefilter("ignore", UserWarning)
+
+        return None, setter
+
+    def warn_in_worker():
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.warn("worker warning", UserWarning, stacklevel=1)
+        return len(caught)
+
+    register_global_parallel_callback(callback)
+    with joblib.Parallel(n_jobs=2) as parallel_runner:
+        filtered_result = parallel_runner(delayed(warn_in_worker)() for _ in range(2))
+        restored_result = parallel_runner(joblib.delayed(warn_in_worker)() for _ in range(2))
+
+    assert filtered_result == [0, 0]
+    assert restored_result == [1, 1]
 
 
 def test_doctest():

--- a/tests/test_pipelines/test_optimize.py
+++ b/tests/test_pipelines/test_optimize.py
@@ -358,13 +358,11 @@ class TestGridSearch:
         with pytest.raises(TestError, match="Testing failed") as e:
             gs.optimize(DummyDataset())
 
-        assert (
-            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}} > score:"
-            in str(e.value)
+        assert str(e.value) == "Testing failed."
+        assert e.value.__notes__[0].startswith("Context: score:")
+        assert e.value.__notes__[1] == (
+            f"Context: parameter_candidate: i={error_para - 1}, parameters={{'para': {error_para}}}"
         )
-        assert e.value.__notes__ == [
-            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}"
-        ]
 
 
 class TestGridSearchCV:
@@ -740,15 +738,12 @@ class TestGridSearchCV:
         with pytest.raises(OptimizationError, match="Optimization failed") as e:
             gs.optimize(DummyDataset())
 
-        assert (
-            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}} "
-            f"> cv_fold: index={error_fold} > optimize:" in str(e.value)
-        )
-        assert e.value.__notes__ == [
-            f"Context: cv_fold: index={error_fold}",
-            f"Context: parameter_candidate: index={error_para - 1}, parameters={{'para': {error_para}}}",
+        assert str(e.value) == "Optimization failed."
+        assert e.value.__notes__[0].startswith("Context: optimize:")
+        assert e.value.__notes__[1:] == [
+            f"Context: cv_fold: i={error_fold}",
+            f"Context: parameter_candidate: i={error_para - 1}, parameters={{'para': {error_para}}}",
         ]
-        assert e.value.__cause__.__notes__[0].startswith("Context: optimize:")
 
 
 class TestOptimize:

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -153,6 +153,29 @@ class TestScorer:
             assert kwargs.pop("step") == i
             assert kwargs == {}
 
+    def test_callback_warning_and_error_contain_result_iteration_context(self):
+        """Callback diagnostics identify the internally consumed scoring result."""
+
+        def callback(*, step, **_):
+            if step == 1:
+                warnings.warn("callback warning", UserWarning, stacklevel=1)
+                raise RuntimeError("callback failed")
+
+        scorer = Scorer(
+            lambda _pipeline, _datapoint: 1,
+            single_score_callback=callback,
+            progress_bar=False,
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(RuntimeError, match="callback failed") as error:
+                scorer(DummyOptimizablePipeline(), DummyDataset())
+
+        expected_context = "single_score_callback: i=1"
+        assert str(caught[0].message) == f"callback warning\n[{expected_context}] callback warning"
+        assert error.value.__notes__ == [f"Context: {expected_context}"]
+
     def test_documented_callback_signature_valid(self):
         def callback(*, step: int, scores: Sequence[float], **_):
             assert isinstance(step, int)

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -108,6 +108,32 @@ class TestScorer:
             scorer(pipe, data)
         assert "Aggregator for score 'val' raised an exception" in str(e.value)
 
+    def test_aggregation_warning_and_error_contain_score_iteration_context(self):
+        """Custom-aggregator diagnostics identify the internally iterated score."""
+
+        def failing_aggregation(_values):
+            warnings.warn("aggregation warning", UserWarning, stacklevel=1)
+            raise RuntimeError("aggregation failed")
+
+        valid_aggregator = FloatAggregator(np.mean)
+        failing_aggregator = FloatAggregator(failing_aggregation)
+
+        def score_func(_pipeline, _datapoint):
+            return {
+                "valid": valid_aggregator(1.0),
+                "failing": failing_aggregator(2.0),
+            }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(ValidationError, match="Aggregator for score 'failing'") as error:
+                Scorer(score_func)(DummyOptimizablePipeline(), DummyDataset())
+
+        expected_context = "score_aggregation: i=1, score_name='failing'"
+        assert str(caught[0].message) == f"aggregation warning\n[{expected_context}] aggregation warning"
+        assert error.value.__notes__ == [f"Context: {expected_context}"]
+        assert isinstance(error.value.__cause__, RuntimeError)
+
     def test_callback_called(self):
         mock_score_func = Mock(return_value=1)
         mock_callback = Mock()

--- a/tests/test_pipelines/test_scorer.py
+++ b/tests/test_pipelines/test_scorer.py
@@ -17,6 +17,7 @@ from tests.test_pipelines.conftest import (
 )
 from tpcp import Pipeline
 from tpcp.exceptions import ScorerFailedError, ValidationError
+from tpcp.misc import warning_error_context
 from tpcp.validate import Scorer
 from tpcp.validate._scorer import Aggregator, FloatAggregator, _validate_scorer, no_agg
 
@@ -175,6 +176,24 @@ class TestScorer:
         expected_context = "single_score_callback: i=1"
         assert str(caught[0].message) == f"callback warning\n[{expected_context}] callback warning"
         assert error.value.__notes__ == [f"Context: {expected_context}"]
+
+    def test_parallel_worker_records_are_recovered(self):
+        def score_func(_pipeline, datapoint):
+            value = datapoint.group_label.value
+            warnings.warn(f"worker warning {value}", UserWarning, stacklevel=1)
+            return value
+
+        with warnings.catch_warnings(), warning_error_context("program", record_only=True) as context:
+            warnings.simplefilter("always")
+            agg_score, single_scores = Scorer(score_func, n_jobs=2, progress_bar=False)(
+                DummyOptimizablePipeline(), DummyDataset()
+            )
+
+        assert agg_score == np.mean(single_scores)
+        assert [str(record.message) for record in context.records] == [
+            f"worker warning {i}" for i in range(len(DummyDataset()))
+        ]
+        assert all(record.context.startswith("program > datapoint: index=") for record in context.records)
 
     def test_documented_callback_signature_valid(self):
         def callback(*, step: int, scores: Sequence[float], **_):

--- a/tests/test_pipelines/test_validate.py
+++ b/tests/test_pipelines/test_validate.py
@@ -90,7 +90,8 @@ class TestValidate:
         with pytest.raises(TestError, match="Testing failed") as e:
             validate(DummyPipeline(), BrokenGroupLabelsDataset(), scoring=dummy_single_score_func)
 
-        assert str(e.value) == "Testing failed.\nContext: score"
+        assert str(e.value) == "Testing failed."
+        assert e.value.__notes__ == ["Context: score"]
         assert isinstance(e.value.__cause__, RuntimeError)
 
     @pytest.mark.parametrize(
@@ -253,17 +254,20 @@ class TestCrossValidate:
             assert o is not optimizer
 
     @pytest.mark.parametrize("error_fold", [0, 2])
-    def test_cross_validate_opti_error(self, error_fold):
+    @pytest.mark.parametrize("n_jobs", [1, 2])
+    def test_cross_validate_opti_error(self, error_fold, n_jobs):
         with pytest.raises(OptimizationError, match="Optimization failed") as e:
             cross_validate(
                 Optimize(CustomOptimizablePipelineWithOptiError(error_fold=error_fold)),
                 DummyDataset(),
                 scoring=dummy_single_score_func,
                 cv=5,
+                n_jobs=n_jobs,
             )
 
-        assert f"Context: cv_fold: index={error_fold} > optimize:" in str(e.value)
-        assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
+        assert str(e.value) == "Optimization failed."
+        assert e.value.__notes__[0].startswith("Context: optimize:")
+        assert e.value.__notes__[1] == f"Context: cv_fold: i={error_fold}"
 
     @pytest.mark.parametrize("error_fold", [0, 2])
     def test_cross_validate_test_error(self, error_fold):
@@ -279,9 +283,9 @@ class TestCrossValidate:
                 cv=5,
             )
 
-        assert f"Context: cv_fold: index={error_fold} > test_score:" in str(e.value)
-        assert e.value.__notes__ == [f"Context: cv_fold: index={error_fold}"]
-        assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
+        assert str(e.value) == "Testing failed."
+        assert e.value.__notes__[0].startswith("Context: test_score:")
+        assert e.value.__notes__[1] == f"Context: cv_fold: i={error_fold}"
         assert e.value.__cause__.__cause__.__notes__ == [
             f"Context: datapoint: index=0, group_label=DummyDatasetGroupLabel(value={error_fold})"
         ]
@@ -308,13 +312,13 @@ class TestCrossValidate:
             )
 
         if return_train_score:
-            assert "Context: cv_fold: index=0 > train_score:" in str(e.value)
-            assert e.value.__notes__ == ["Context: cv_fold: index=0"]
-            assert e.value.__cause__.__notes__[0].startswith("Context: train_score:")
+            assert str(e.value) == "Testing failed."
+            assert e.value.__notes__[0].startswith("Context: train_score:")
+            assert e.value.__notes__[1] == "Context: cv_fold: i=0"
         else:
-            assert "Context: cv_fold: index=1 > test_score:" in str(e.value)
-            assert e.value.__notes__ == ["Context: cv_fold: index=1"]
-            assert e.value.__cause__.__notes__[0].startswith("Context: test_score:")
+            assert str(e.value) == "Testing failed."
+            assert e.value.__notes__[0].startswith("Context: test_score:")
+            assert e.value.__notes__[1] == "Context: cv_fold: i=1"
 
     def test_cross_validate_optimizer_are_cloned(self):
         results = cross_validate(


### PR DESCRIPTION
## Summary

Follow-up to #131. This PR expands the TPCP Joblib seam so runtime context can cross process boundaries and successful worker diagnostics can return to the parent without changing task return values.

## Changes

- Restore active warning/error context stacks for every `tpcp.parallel.delayed` task.
  - Context providers are snapshotted once when a process-worker task starts.
  - Warning filters and side-channel state are captured for each concrete task, including when a reusable delayed callable is used.
  - Worker state is scoped to one task, including reused processes.
  - With `n_jobs=1`, execution remains inline, so providers retain normal dynamic behavior and escaping exceptions are recorded directly by the active parent context.
- Restore captured Python warning filters in process workers.
  - Thread workers share process-global warning filters and use the filters active when each task executes.
- Add public `tpcp.parallel.Parallel` and application-defined side channels through `register_parallel_side_channel`.
  - Successful task data is merged in the parent for list and generator results.
  - Plain `joblib.Parallel` remains compatible for restore-only execution.
  - Failed worker tasks retain native Joblib exception behavior and do not return side-channel data.
- Migrate all internal TPCP parallel execution to the context-aware abstraction.
- Use propagated iteration context in validation, grid search, cross-validation, scoring, and optimization task construction.
- Expand the multiprocessing guide with callbacks, custom side channels, and TPCP-managed runtime features.
- Extend the executable warning/error context gallery example to show restored parent context, worker-local nested context, and recovered warning and contextual-print records. The example explicitly calls out that both TPCP parallel helpers are required.

## Breaking changes

- Names beginning with `__tpcp_internal__.` are now reserved for TPCP parallel callbacks and side channels. Existing user registrations using that prefix must be renamed.
- Contextualized warning and exception output replaces the previous ad-hoc scorer/validation error strings, as documented in the changelog.
- Private `_score` and `_optimize_and_score` no longer accept `error_info` or `context`; callers activate `warning_error_context` while constructing delayed tasks.

All breaking changes and migrations are documented in `CHANGELOG.md` with links to #131 and this PR.

## Validation

- `uv run poe test` → `627 passed, 11 skipped`
- Full Python 3.9 suite → `615 passed, 13 skipped`
- `uv run poe ci_check` → passed
- `uv run poe docs_clean` → succeeded; all 23 gallery examples executed, with existing documentation warnings only
- `git diff --check origin/main..HEAD` → passed
- Whole-stack Roborev review and all follow-up reviews → resolved and closed
